### PR TITLE
feat: add maintenance shortcut aliases

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -291,6 +291,11 @@ alias gl='git log --oneline --graph --decorate'
 alias battery='battery-status'
 alias batteryv='battery-status -v'  # verbose output
 
+# Daily maintenance shortcuts
+alias mr='~/daily-maintenance-control.sh run'      # maintenance run
+alias ms='~/daily-maintenance-control.sh status'   # maintenance status
+alias ml='~/daily-maintenance-control.sh logs'     # maintenance logs
+
 # ============================================================================
 # Shell Options
 # ============================================================================


### PR DESCRIPTION
## Summary
- Added three concise shell aliases for daily maintenance control
- Verified no conflicts with existing commands before implementation
- Improves workflow efficiency for manual maintenance operations

## Changes
- Added `mr` alias - **m**aintenance **r**un (executes `~/daily-maintenance-control.sh run`)
- Added `ms` alias - **m**aintenance **s**tatus (executes `~/daily-maintenance-control.sh status`)  
- Added `ml` alias - **m**aintenance **l**ogs (executes `~/daily-maintenance-control.sh logs`)

## Motivation
After implementing the automated daily maintenance system with catch-up functionality, there was a need for quick manual execution of maintenance tasks. The original command `~/daily-maintenance-control.sh run` was too verbose for frequent use.

## Testing
- ✅ Verified no command conflicts with `mr`, `ms`, `ml`
- ✅ Tested alias resolution in shell
- ✅ Confirmed commands are properly commented for clarity

## Usage
After sourcing `.zshrc` or opening a new terminal:
```bash
mr  # Manually run all maintenance tasks (bypass date check)
ms  # Check if automation is active
ml  # View recent maintenance logs
```

This complements the automated system that runs daily at 9 AM with RunAtLoad catch-up.