### PR TITLE
Enhance Ghostty with transparency and Claude Code integration

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -12,17 +12,39 @@ window-padding-y = 10
 window-decoration = true
 window-theme = auto
 
+# Transparency and visual effects for macOS liquid visuals
+background-opacity = 0.88
+background-blur-radius = 20
+macos-titlebar-style = transparent
+
 # Cursor settings
 cursor-style = block
-cursor-blink = true
-
-# Modern terminal features
-copy-on-select = true
-clipboard-read = allow
-clipboard-write = allow
+cursor-style-blink = true
 
 # Custom keybinds
 keybind = shift+enter=text:\n
 keybind = cmd+k=clear_screen
-keybind = cmd+shift+d=split_right
-keybind = cmd+d=split_down
+keybind = cmd+shift+d=new_split:right
+keybind = cmd+d=new_split:down
+
+# Shell Integration for Claude Code
+shell-integration = detect
+shell-integration-features = cursor,sudo,title,ssh-env
+
+# Enhanced clipboard for better Claude Code integration
+clipboard-read = allow
+clipboard-write = allow
+clipboard-trim-trailing-spaces = true
+clipboard-paste-protection = true
+clipboard-paste-bracketed-safe = true
+
+# Mouse and selection improvements
+mouse-hide-while-typing = true
+focus-follows-mouse = true
+copy-on-select = clipboard
+
+# Link handling
+link-url = true
+
+# Additional features
+confirm-close-surface = false

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ configurations for macOS development environment.
 ### Core Configurations
 
 - **Shell**: Zsh configuration with zinit plugin manager
-- **Editor**: Neovim (LazyVim) and Zed configurations  
-- **Terminal**: tmux and Ghostty configurations
+- **Editor**: Neovim (LazyVim) and Zed configurations
+- **Terminal**: tmux and Ghostty configurations (with transparency and Claude Code integration)
 - **Package Management**: Brewfile for Homebrew packages
 - **Git**: Global git configuration
 - **Tools**: ripgrep, bat configurations
@@ -233,6 +233,27 @@ launchctl unload ~/Library/LaunchAgents/com.daily-maintenance.plist
 rm ~/Library/Logs/daily-maintenance*.log
 ```
 
+## 👻 Ghostty Terminal Configuration
+
+### Features
+
+- **Transparency**: Background opacity (0.88) with blur effect for macOS liquid visuals
+- **Shell Integration**: Enhanced shell integration for better Claude Code support
+- **Smart Clipboard**: Protected paste with bracketed paste mode
+- **Custom Keybinds**: Split panes with `Cmd+D` (down) and `Cmd+Shift+D` (right)
+- **Theme**: Catppuccin Mocha with Hack Nerd Font
+
+### Key Settings
+
+- Transparent background with blur for modern macOS aesthetic
+- Shell integration with working directory tracking (OSC 7)
+- Enhanced clipboard features with paste protection
+- Mouse support with focus-follows-mouse
+- Link clicking enabled
+
+Note: After modifying Ghostty config, restart the application for transparency
+changes to take effect.
+
 ## 🖥️ Tmux Configuration
 
 ### Setup
@@ -305,6 +326,7 @@ nvim --headless '+Lazy! sync' +qa
 ├── .config/
 │   ├── nvim/          # Neovim configuration (LazyVim)
 │   ├── zed/           # Zed editor configuration
+│   ├── ghostty/       # Ghostty terminal configuration
 │   ├── bat/           # Bat themes
 │   └── ripgrep/       # Ripgrep configuration
 ├── .local/


### PR DESCRIPTION
## Summary
- Added transparency and blur effects for macOS liquid visuals
- Configured comprehensive shell integration for Claude Code support
- Enhanced clipboard and paste safety features
- Improved mouse and selection behavior

## Changes Made

### Visual Enhancements
- **Background transparency**: Set to 0.88 opacity with 20px blur radius
- **Transparent titlebar**: macOS titlebar style set to transparent
- **Result**: Beautiful liquid visual effect matching macOS 26's aesthetic

### Claude Code Integration
- **Shell integration**: Enabled with cursor, sudo, title, and ssh-env features
- **OSC sequences**: Support for OSC 7 (working directory) and OSC 133 (prompt marking)
- **Clipboard enhancements**: OSC 52 support with paste protection
- **Benefit**: Seamless integration with Claude Code's terminal features

### Quality of Life Improvements
- **Mouse support**: Focus-follows-mouse and hide-while-typing
- **Selection**: Copy-on-select to clipboard
- **Link handling**: URL recognition and clicking support
- **Keybinds**: Fixed split pane actions (new_split:down/right)

### Documentation
- Updated README.md with Ghostty configuration section
- Added feature descriptions and usage notes
- Updated repository structure documentation

## Test Plan
- [x] Validate configuration with `ghostty +validate-config`
- [x] Restart Ghostty and verify transparency/blur effects
- [x] Test split pane keybinds (Cmd+D, Cmd+Shift+D)
- [x] Verify clipboard operations and paste protection
- [x] Test shell integration features
- [ ] Pull on another machine to verify compatibility