### PR TITLE
Remove VPN clients from Brewfile

### DIFF
--- a/.config/yadm/bootstrap
+++ b/.config/yadm/bootstrap
@@ -51,7 +51,7 @@ fi
 if [ -f "$HOME/Brewfile" ] && command -v brew &> /dev/null; then
     echo "📦 Installing Brewfile packages..."
     echo "  Note: Some casks may require sudo password. Run 'brew bundle' manually if needed."
-    brew bundle --file="$HOME/Brewfile" --no-lock || true
+    brew bundle --file="$HOME/Brewfile" || true
 fi
 
 # Setup tmux plugin manager

--- a/Brewfile
+++ b/Brewfile
@@ -105,8 +105,6 @@ cask "ghostty"
 cask "git-credential-manager"
 # Free and open-source media player
 cask "iina"
-# VPN client for secure internet access and private browsing
-cask "nordvpn"
 # Control your tools with a few keystrokes
 cask "raycast"
 # Window snapping tool
@@ -117,8 +115,6 @@ cask "setapp"
 cask "soundsource"
 # Music streaming service
 cask "spotify"
-# VPN client for secure internet access and private browsing
-cask "surfshark"
 # Rust-based terminal
 cask "warp"
 # Multiplayer code editor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,6 @@ Runs validation before allowing commits
 - **Development**: Ghostty, Warp (terminals)
 - **Media**: IINA, Spotify
 - **Utilities**: BetterDisplay, Raycast, Rectangle Pro, SoundSource
-- **VPN**: NordVPN, Surfshark
 - **Fonts**: Hack Nerd Font
 
 ## Custom Scripts


### PR DESCRIPTION
## Summary
- Removed NordVPN and Surfshark casks from Brewfile
- Updated CLAUDE.md documentation

## Reason
No longer using these VPN clients

## Test Plan
- [x] Verify Brewfile is valid
- [x] Documentation updated
- [ ] Run `brew bundle cleanup` to remove installed casks if needed