### PR TITLE
feat(nvim,shell,ghostty): fix ibl highlights, zoxide doctor, and UI polish

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -44,6 +44,10 @@ keybind = cmd+shift+comma=reload_config
 keybind = cmd+up=jump_to_prompt:-1
 keybind = cmd+down=jump_to_prompt:1
 keybind = cmd+shift+enter=toggle_split_zoom
+keybind = cmd+alt+h=goto_split:left
+keybind = cmd+alt+j=goto_split:bottom
+keybind = cmd+alt+k=goto_split:top
+keybind = cmd+alt+l=goto_split:right
 
 # Shell Integration for Claude Code
 shell-integration = detect

--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -5,7 +5,7 @@ font-thicken = false
 adjust-cell-width = 1%
 
 # Performance
-scrollback-limit = 10000
+scrollback-limit = 10000000
 
 # Window settings
 window-padding-x = 10
@@ -89,6 +89,7 @@ desktop-notifications = true
 # Quick Terminal (Quake-style dropdown from top of screen)
 keybind = global:cmd+grave_accent=toggle_quick_terminal
 quick-terminal-position = top
+quick-terminal-screen = mouse
 quick-terminal-size = 70%
 quick-terminal-animation-duration = 0.15
 quick-terminal-autohide = true

--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -45,8 +45,8 @@ keybind = cmd+up=jump_to_prompt:-1
 keybind = cmd+down=jump_to_prompt:1
 keybind = cmd+shift+enter=toggle_split_zoom
 keybind = cmd+alt+h=goto_split:left
-keybind = cmd+alt+j=goto_split:bottom
-keybind = cmd+alt+k=goto_split:top
+keybind = cmd+alt+j=goto_split:down
+keybind = cmd+alt+k=goto_split:up
 keybind = cmd+alt+l=goto_split:right
 
 # Shell Integration for Claude Code

--- a/.config/nvim/README.md
+++ b/.config/nvim/README.md
@@ -27,6 +27,8 @@ Enabled via `lazyvim.json`:
 - `lang.typescript` -- ts\_ls, prettier, eslint
 - `test.core` -- Run tests from editor (`<leader>t` bindings)
 - `ui.treesitter-context` -- Sticky header showing current function/class
+- `editor.outline` -- Symbol outline sidebar (`<leader>cs`)
+- `ui.mini-indentscope` -- Animated indent guide for current scope
 
 ## Custom Plugins
 
@@ -35,6 +37,14 @@ Enabled via `lazyvim.json`:
 - **Custom Dashboard** with ASCII art header (`lua/plugins/dashboard.lua`)
 - **Smooth Scroll** tuning — 150ms linear animation
   (`lua/plugins/snacks-extras.lua`)
+- **Dropbar** — VS Code-style breadcrumb navigation bar
+  (`lua/plugins/dropbar.lua`)
+- **Gitsigns inline blame** — GitLens-style inline git blame toggle
+  (`lua/plugins/gitsigns-blame.lua`)
+- **Glance** — Peek definitions, references, type definitions, and
+  implementations in a floating window (`lua/plugins/glance.lua`)
+- **Rainbow Indent** — Rainbow-colored indent guides for all levels
+  via indent-blankline + rainbow-delimiters (`lua/plugins/rainbow-indent.lua`)
 
 ## Notable Options
 

--- a/.config/nvim/lazyvim.json
+++ b/.config/nvim/lazyvim.json
@@ -6,6 +6,7 @@
     "lazyvim.plugins.extras.editor.dial",
     "lazyvim.plugins.extras.editor.harpoon2",
     "lazyvim.plugins.extras.editor.refactoring",
+    "lazyvim.plugins.extras.lang.clangd",
     "lazyvim.plugins.extras.lang.docker",
     "lazyvim.plugins.extras.lang.go",
     "lazyvim.plugins.extras.lang.java",
@@ -13,12 +14,15 @@
     "lazyvim.plugins.extras.lang.markdown",
     "lazyvim.plugins.extras.lang.python",
     "lazyvim.plugins.extras.lang.rust",
+    "lazyvim.plugins.extras.lang.tex",
     "lazyvim.plugins.extras.lang.toml",
     "lazyvim.plugins.extras.lang.typescript",
     "lazyvim.plugins.extras.editor.illuminate",
     "lazyvim.plugins.extras.editor.inc-rename",
     "lazyvim.plugins.extras.test.core",
-    "lazyvim.plugins.extras.ui.treesitter-context"
+    "lazyvim.plugins.extras.ui.treesitter-context",
+    "lazyvim.plugins.extras.editor.outline",
+    "lazyvim.plugins.extras.ui.mini-indentscope"
   ],
   "install_version": 7,
   "news": {

--- a/.config/nvim/lua/config/autocmds.lua
+++ b/.config/nvim/lua/config/autocmds.lua
@@ -7,25 +7,19 @@
 -- Or remove existing autocmds by their group name (which is prefixed with `lazyvim_` for the defaults)
 -- e.g. vim.api.nvim_del_augroup_by_name("lazyvim_wrap_spell")
 
+local function set_transparent_bg()
+  local groups = { "Normal", "NormalNC", "NormalFloat", "SnacksNormal",
+    "SnacksNormalNC", "StatusLine", "StatusLineNC" }
+  for _, group in ipairs(groups) do
+    vim.api.nvim_set_hl(0, group, { bg = "NONE" })
+  end
+end
+
 vim.api.nvim_create_autocmd("ColorScheme", {
   pattern = "*",
-  callback = function()
-    vim.api.nvim_set_hl(0, "Normal", { bg = "NONE" })
-    vim.api.nvim_set_hl(0, "NormalNC", { bg = "NONE" })
-    vim.api.nvim_set_hl(0, "NormalFloat", { bg = "NONE" })
-    vim.api.nvim_set_hl(0, "SnacksNormal", { bg = "NONE" })
-    vim.api.nvim_set_hl(0, "SnacksNormalNC", { bg = "NONE" })
-    vim.api.nvim_set_hl(0, "StatusLine", { bg = "NONE" })
-    vim.api.nvim_set_hl(0, "StatusLineNC", { bg = "NONE" })
-  end,
+  callback = set_transparent_bg,
 })
 
 -- Apply immediately since this file loads on VeryLazy (after the
 -- initial colorscheme has already been set)
-vim.api.nvim_set_hl(0, "Normal", { bg = "NONE" })
-vim.api.nvim_set_hl(0, "NormalNC", { bg = "NONE" })
-vim.api.nvim_set_hl(0, "NormalFloat", { bg = "NONE" })
-vim.api.nvim_set_hl(0, "SnacksNormal", { bg = "NONE" })
-vim.api.nvim_set_hl(0, "SnacksNormalNC", { bg = "NONE" })
-vim.api.nvim_set_hl(0, "StatusLine", { bg = "NONE" })
-vim.api.nvim_set_hl(0, "StatusLineNC", { bg = "NONE" })
+set_transparent_bg()

--- a/.config/nvim/lua/plugins/catppuccin.lua
+++ b/.config/nvim/lua/plugins/catppuccin.lua
@@ -151,6 +151,11 @@ return {
         },
         semantic_tokens = true,
         treesitter_context = true,
+        rainbow_delimiters = true,
+        dropbar = {
+          enabled = true,
+          color_mode = "fg",
+        },
       },
     },
   },

--- a/.config/nvim/lua/plugins/rainbow-indent.lua
+++ b/.config/nvim/lua/plugins/rainbow-indent.lua
@@ -1,0 +1,54 @@
+local highlight = {
+  "RainbowRed",
+  "RainbowYellow",
+  "RainbowBlue",
+  "RainbowOrange",
+  "RainbowGreen",
+  "RainbowViolet",
+  "RainbowCyan",
+}
+
+return {
+  -- Rainbow delimiters (colored brackets + provides shared highlight names)
+  {
+    "HiPhish/rainbow-delimiters.nvim",
+    event = "LazyFile",
+    config = function()
+      local rainbow = require("rainbow-delimiters")
+      vim.g.rainbow_delimiters = {
+        strategy = {
+          [""] = rainbow.strategy["global"],
+        },
+        query = {
+          [""] = "rainbow-delimiters",
+        },
+        highlight = highlight,
+      }
+    end,
+  },
+
+  -- Indent-blankline with rainbow colors (VS Code-style indent guides)
+  {
+    "lukas-reineke/indent-blankline.nvim",
+    event = "LazyFile",
+    main = "ibl",
+    opts = {
+      indent = { char = "│", highlight = highlight },
+      scope = { enabled = false }, -- mini.indentscope handles scope
+    },
+    config = function(_, opts)
+      local hooks = require("ibl.hooks")
+      -- Define highlight groups before ibl uses them (Catppuccin Mocha palette)
+      hooks.register(hooks.type.HIGHLIGHT_SETUP, function()
+        vim.api.nvim_set_hl(0, "RainbowRed", { fg = "#f38ba8" })
+        vim.api.nvim_set_hl(0, "RainbowYellow", { fg = "#f9e2af" })
+        vim.api.nvim_set_hl(0, "RainbowBlue", { fg = "#89b4fa" })
+        vim.api.nvim_set_hl(0, "RainbowOrange", { fg = "#fab387" })
+        vim.api.nvim_set_hl(0, "RainbowGreen", { fg = "#a6e3a1" })
+        vim.api.nvim_set_hl(0, "RainbowViolet", { fg = "#cba6f7" })
+        vim.api.nvim_set_hl(0, "RainbowCyan", { fg = "#94e2d5" })
+      end)
+      require("ibl").setup(opts)
+    end,
+  },
+}

--- a/.config/nvim/lua/plugins/vscode-ui.lua
+++ b/.config/nvim/lua/plugins/vscode-ui.lua
@@ -1,0 +1,65 @@
+return {
+  -- Breadcrumb navigation bar (like VS Code breadcrumbs)
+  {
+    "Bekaboo/dropbar.nvim",
+    event = "LazyFile",
+    opts = {
+      bar = {
+        sources = function(buf, _)
+          local sources = require("dropbar.sources")
+          local utils = require("dropbar.utils")
+          if vim.bo[buf].ft == "markdown" then
+            return { sources.markdown }
+          end
+          if vim.bo[buf].buftype == "terminal" then
+            return { sources.terminal }
+          end
+          return {
+            utils.source.fallback({
+              sources.lsp,
+              sources.treesitter,
+            }),
+          }
+        end,
+      },
+    },
+  },
+
+  -- Inline git blame (like VS Code GitLens)
+  {
+    "lewis6991/gitsigns.nvim",
+    opts = {
+      current_line_blame = true,
+      current_line_blame_opts = {
+        virt_text = true,
+        virt_text_pos = "eol",
+        delay = 300,
+      },
+      current_line_blame_formatter = "<author>, <author_time:%R> • <summary>",
+    },
+    keys = {
+      { "<leader>uB", "<cmd>Gitsigns toggle_current_line_blame<cr>", desc = "Toggle Git Blame" },
+    },
+  },
+
+  -- Peek definition/references (like VS Code Alt+F12)
+  {
+    "dnlhc/glance.nvim",
+    cmd = "Glance",
+    opts = {
+      border = {
+        enable = true,
+      },
+      theme = {
+        enable = true,
+        mode = "auto",
+      },
+    },
+    keys = {
+      { "gD", "<cmd>Glance definitions<cr>", desc = "Glance Definition" },
+      { "gR", "<cmd>Glance references<cr>", desc = "Glance References" },
+      { "gY", "<cmd>Glance type_definitions<cr>", desc = "Glance Type Definition" },
+      { "gM", "<cmd>Glance implementations<cr>", desc = "Glance Implementations" },
+    },
+  },
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,11 +577,45 @@ jobs:
             echo "No shell scripts found to test"
           fi
 
+  dotfiles-test-suite:
+    name: Dotfiles Test Suite
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up test environment
+        run: |
+          # Point HOME to workspace so dotfiles are found at ~/
+          export HOME=$GITHUB_WORKSPACE
+
+          # Create directories that the test expects
+          mkdir -p "$HOME/.config"
+
+          # Symlink configs that live under .config/
+          for dir in ghostty kitty starship.toml atuin yazi mise; do
+            if [ -e ".config/$dir" ]; then
+              ln -sfn "$GITHUB_WORKSPACE/.config/$dir" "$HOME/.config/$dir"
+            fi
+          done
+
+      - name: Install validation tools
+        run: |
+          brew install uv || true
+          uv tool install beautysh --with setuptools || true
+          export PATH="$HOME/.local/bin:$PATH"
+
+      - name: Run test-dotfiles.sh
+        run: |
+          export HOME=$GITHUB_WORKSPACE
+          export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
+          bash test-dotfiles.sh
+
   summary:
     name: CI Summary
     needs: [lint-all, shellcheck, bash-syntax, zsh-syntax, go-validation,
             yaml-validation, bootstrap-test, macos-integration, documentation,
-            security-scan, compatibility-matrix]
+            security-scan, compatibility-matrix, dotfiles-test-suite]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -22,7 +22,7 @@ bind r source-file ~/.tmux.conf
 
 set -g prefix C-a
 
-bind-key C-a send-prefix
+bind C-a send-prefix
 
 unbind %
 bind \\ split-window -h -c "#{pane_current_path}"
@@ -38,13 +38,12 @@ set -g mouse on
 # Start windows and panes at 1, not 0
 set -g base-index 1
 set -g pane-base-index 1
-set-option -g pane-base-index 1
-set-option -g renumber-windows on
+set -g renumber-windows on
 
-bind-key h select-pane -L
-bind-key j select-pane -D
-bind-key k select-pane -U
-bind-key l select-pane -R
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
 
 # Repeatable resize (hold prefix, tap H/J/K/L repeatedly)
 bind -r H resize-pane -L 5
@@ -57,7 +56,7 @@ bind -r < swap-window -d -t -1
 bind -r > swap-window -d -t +1
 
 
-bind-key "T" run-shell "sesh connect \"$(
+bind "T" run-shell "sesh connect \"$(
   sesh list --icons | fzf-tmux -p 80%,70% \
     --no-sort --ansi --border-label ' sesh ' --prompt '⚡  ' \
     --header '  ^a all ^t tmux ^g configs ^x zoxide ^d tmux kill ^f find' \
@@ -72,7 +71,7 @@ bind-key "T" run-shell "sesh connect \"$(
     --preview 'sesh preview {}'
 )\""
 
-set-option -g status-position top
+set -g status-position top
 
 # List of plugins
 set -g @plugin 'tmux-plugins/tpm'

--- a/.zshrc
+++ b/.zshrc
@@ -282,10 +282,7 @@ if command -v carapace &> /dev/null; then
     source <(carapace _carapace)
 fi
 
-# Zoxide (better cd)
-if command -v zoxide &> /dev/null; then
-    eval "$(zoxide init zsh)"
-fi
+# Zoxide - init moved to end of file (before starship) to satisfy zoxide doctor
 
 # The fuck (command correction)
 if command -v thefuck &> /dev/null; then
@@ -326,7 +323,10 @@ alias hh='atuin history list --cmd-only | bat -l bash --style=plain'
 
 # Shortcuts
 alias c='clear'
-alias cd='z'  # Use zoxide for cd
+# Use zoxide for cd (skip in Claude Code to avoid interference)
+if [[ -z "$CLAUDECODE" ]]; then
+    alias cd='z'
+fi
 alias python='python3'
 alias pip='pip3'
 
@@ -474,7 +474,7 @@ zstyle ':completion:*:cd:*' ignored-patterns '(*/.git|*/.npm|*/node_modules|*/.c
 export BAT_THEME="Catppuccin Mocha"
 
 # ============================================================================
-# Prompt (Starship) - Load AFTER all shell integrations to avoid conflicts
+# Prompt (Starship) - Load before zoxide so zoxide doctor check passes
 # ============================================================================
 
 eval "$(starship init zsh)"
@@ -522,3 +522,11 @@ ssht() {
 
 # Source private/work specific configs if exists
 [[ -f "$HOME/.zshrc.local" ]] && source "$HOME/.zshrc.local"
+
+# ============================================================================
+# Zoxide (better cd) - Load LAST to satisfy zoxide doctor check
+# ============================================================================
+
+if command -v zoxide &> /dev/null; then
+    eval "$(zoxide init zsh)"
+fi

--- a/.zshrc
+++ b/.zshrc
@@ -6,7 +6,7 @@
 
 # Use xterm-ghostty locally (enables Ghostty-specific capabilities)
 # Remote machines get xterm-256color via SSH SetEnv (see ~/.ssh/config)
-if [[ -z "$SSH_CONNECTION" ]] && infocmp xterm-ghostty &>/dev/null 2>&1; then
+if [[ -z "$SSH_CONNECTION" ]] && infocmp xterm-ghostty &>/dev/null; then
     export TERM="xterm-ghostty"
 else
     export TERM="xterm-256color"
@@ -96,10 +96,6 @@ zinit light-mode for \
 # Essential Plugins (Load immediately)
 # ============================================================================
 
-# Initialize completion system first (required for compdef)
-autoload -Uz compinit
-compinit
-
 # OMZ Libraries (load first as other plugins may depend on them)
 # Note: functions.zsh must come before termsupport.zsh (provides omz_urlencode)
 zinit snippet OMZ::lib/functions.zsh
@@ -119,6 +115,10 @@ for i in {1..9}; do alias $i="builtin cd -$i"; done
 setopt hist_ignore_all_dups
 setopt hist_save_no_dups
 setopt hist_find_no_dups
+
+# Initialize completion system (required by OMZ plugins that use compdef)
+autoload -Uz compinit
+compinit -C
 
 # OMZ Plugins (via Zinit for better control)
 zinit snippet OMZP::git
@@ -150,12 +150,10 @@ zinit light zdharma-continuum/fast-syntax-highlighting
 
 # Autosuggestions and completions
 zinit wait lucid for \
-    atinit"zicompinit; zicdreplay" \
+    blockf atinit"zicompinit; zicdreplay" \
     zsh-users/zsh-completions \
     atload"_zsh_autosuggest_start" \
-    zsh-users/zsh-autosuggestions \
-    blockf \
-    zsh-users/zsh-completions
+    zsh-users/zsh-autosuggestions
 
 # Additional useful plugins
 zinit wait lucid for \
@@ -359,7 +357,7 @@ alias sls='sesh list -t --icons'  # List only tmux sessions
 # Git extras (in addition to OMZ git plugin)
 alias gs='git status'
 alias gd='git diff'
-alias gl='git log --oneline --graph --decorate'
+alias gl='git log --oneline --graph --decorate --all'
 
 # Battery monitoring
 alias battery='battery-status'
@@ -432,7 +430,7 @@ fi
 
 # FZF-powered git helpers
 alias gb='git branch --sort=-committerdate | fzf --preview "git log --oneline -10 {1}" | xargs git checkout'
-alias gl='git log --oneline --all | fzf --preview "git show --stat {1}" | cut -d" " -f1 | xargs git checkout'
+alias gcof='git log --oneline --all --color=always | fzf --ansi --preview "git show --stat --color=always {1}" | cut -d" " -f1 | xargs git checkout'
 
 # Ripgrep + FZF for interactive code search (Enter opens in nvim)
 rgf() {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ automatically based on context:
   bob version manager, Zed settings
 - **dotfiles-shell** — Zsh/Zinit/Oh-My-Zsh architecture, tmux config,
   terminal emulators (Ghostty, Kitty), Atuin, sesh, aliases
+- **hackernews-summary** — Fetch and summarize top 30 HN stories
+  (full front page) in Traditional Chinese
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -453,6 +453,19 @@ Custom settings for the LazyVim claudecode extra
 | `<leader>ut` | Toggle treesitter-context (sticky function header) |
 | `<leader>ux` | Toggle illuminate (highlight symbol under cursor) |
 | `<leader>cr` | Inc-rename (live rename preview via LSP) |
+| `<leader>cs` | Toggle symbol outline sidebar |
+| `<leader>uB` | Toggle inline git blame (GitLens-style) |
+| `gD` | Glance: peek definition |
+| `gR` | Glance: peek references |
+| `gY` | Glance: peek type definition |
+| `gM` | Glance: peek implementations |
+
+**Automatic features** (no keybinding needed):
+
+- **Dropbar**: VS Code-style breadcrumb navigation bar at top of buffer
+- **Rainbow indent guides**: Each indent level in a different color
+  (like VS Code Indent Rainbow)
+- **Mini-indentscope**: Animated indent guide for current scope
 
 ### Diffview (Git Diff Viewer)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -438,6 +438,18 @@ LazyVim claudecode extra 的自訂設定
 | `<leader>ut` | 切換 treesitter-context（固定函式標頭） |
 | `<leader>ux` | 切換 illuminate（高亮游標下符號） |
 | `<leader>cr` | inc-rename（透過 LSP 即時重新命名預覽） |
+| `<leader>cs` | 切換符號大綱側邊欄 |
+| `<leader>uB` | 切換行內 git blame（GitLens 風格） |
+| `gD` | Glance：預覽定義 |
+| `gR` | Glance：預覽參考 |
+| `gY` | Glance：預覽型別定義 |
+| `gM` | Glance：預覽實作 |
+
+**自動功能**（無需快捷鍵）：
+
+- **Dropbar**：VS Code 風格的麵包屑導航列，顯示於緩衝區頂部
+- **彩虹縮排指引線**：每層縮排以不同顏色顯示（類似 VS Code Indent Rainbow）
+- **Mini-indentscope**：目前作用域的動畫縮排指引線
 
 ### Diffview（Git Diff 檢視器）
 

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -114,6 +114,18 @@ if [ -f ~/.zshrc ]; then
     
     # Basic anti-pattern checks
     run_test "No backticks in .zshrc" "! grep '\`.*\`' ~/.zshrc"
+
+    # Duplicate alias detection
+    run_test "No duplicate aliases in .zshrc" "[ -z \"\$(sed -n 's/^alias \([^=]*\)=.*/\1/p' ~/.zshrc | sort | uniq -d)\" ]"
+
+    # Duplicate zinit plugin detection
+    run_test "No duplicate zinit plugins" "[ -z \"\$(grep -oE 'zinit (light|load|snippet) [^ ;]+' ~/.zshrc | awk '{print \$3}' | sort | uniq -d)\" ]"
+
+    # compinit should appear exactly once (non-commented, non-deferred)
+    run_test "Single compinit call" "[ \"\$(grep -cE '^\s*compinit' ~/.zshrc)\" -le 1 ]"
+
+    # Redundant redirect pattern: &>/dev/null 2>&1
+    run_test "No redundant redirects (&>/dev/null 2>&1)" "! grep '&>/dev/null 2>&1' ~/.zshrc"
 else
     echo -e "${YELLOW}  No .zshrc file found${NC}"
 fi
@@ -181,10 +193,67 @@ fi
 if [ -f "$HOME/.config/yazi/yazi.toml" ]; then
     run_test "Yazi config exists" "[ -s $HOME/.config/yazi/yazi.toml ]"
 fi
+
+# Validate Ghostty config
+if command -v ghostty >/dev/null 2>&1; then
+    run_test "Ghostty config valid" "ghostty +validate-config"
+    if [ -f "$HOME/.config/ghostty/config" ]; then
+        SCROLLBACK=$(sed -n 's/^scrollback-limit *=  *\([0-9]*\)/\1/p' "$HOME/.config/ghostty/config" 2>/dev/null)
+        SCROLLBACK=${SCROLLBACK:-0}
+        run_test "Ghostty scrollback-limit >= 1000000" "[ \"$SCROLLBACK\" -ge 1000000 ]"
+    fi
+fi
+
+# Validate tmux config syntax (parse check only, no server needed)
+if command -v tmux >/dev/null 2>&1 && [ -f "$HOME/.tmux.conf" ]; then
+    run_test "Tmux config exists and non-empty" "[ -s $HOME/.tmux.conf ]"
+fi
+
+# Validate Starship config (TOML syntax)
+if [ -f "$HOME/.config/starship.toml" ]; then
+    run_test "Starship config TOML valid" "python3 -c \"import tomllib, pathlib; tomllib.loads(pathlib.Path('$HOME/.config/starship.toml').read_text())\""
+fi
+
+# Validate Kitty config
+if command -v kitty >/dev/null 2>&1 && [ -f "$HOME/.config/kitty/kitty.conf" ]; then
+    run_test "Kitty config valid" "kitty --config $HOME/.config/kitty/kitty.conf --debug-config 2>&1 | grep -qv 'Error'"
+fi
+
+# Validate Atuin config (TOML syntax)
+if [ -f "$HOME/.config/atuin/config.toml" ]; then
+    run_test "Atuin config TOML valid" "python3 -c \"import tomllib, pathlib; tomllib.loads(pathlib.Path('$HOME/.config/atuin/config.toml').read_text())\""
+fi
 echo
 
-# Test 10: Git/yadm checks
-echo -e "${YELLOW}10. Version Control Checks${NC}"
+# Test 10: Symlink Integrity
+echo -e "${YELLOW}10. Symlink Integrity${NC}"
+
+# Ghostty config symlink
+GHOSTTY_LINK="$HOME/Library/Application Support/com.mitchellh.ghostty/config"
+if [ -e "$GHOSTTY_LINK" ] || [ -L "$GHOSTTY_LINK" ]; then
+    run_test "Ghostty config is symlink" "[ -L \"$GHOSTTY_LINK\" ]"
+    run_test "Ghostty symlink target correct" "[ \"\$(readlink \"$GHOSTTY_LINK\")\" = \"$HOME/.config/ghostty/config\" ]"
+fi
+
+# Critical dotfiles exist and are non-empty
+for dotfile in ~/.zshrc ~/.tmux.conf ~/.gitconfig ~/.config/starship.toml; do
+    if [ -e "$dotfile" ]; then
+        run_test "$(basename $dotfile) exists and non-empty" "[ -s $dotfile ]"
+    fi
+done
+echo
+
+# Test 11: Security Checks
+echo -e "${YELLOW}11. Security Checks${NC}"
+
+# No secrets in yadm-tracked files
+if command -v yadm >/dev/null 2>&1; then
+    run_test "No secrets in tracked files" "[ -z \"\$(yadm list -a 2>/dev/null | xargs grep -lE '(APIKEY|SECRET_KEY|TOKEN|PASSWORD)\s*=' 2>/dev/null | grep -v 'HOMEBREW_NO_ANALYTICS' | grep -v 'test-dotfiles.sh')\" ]"
+fi
+echo
+
+# Test 12: Git/yadm checks
+echo -e "${YELLOW}12. Version Control Checks${NC}"
 run_test "No uncommitted changes" "[ -z \"$(yadm status --porcelain 2>/dev/null)\" ] || yadm status --porcelain"
 echo
 


### PR DESCRIPTION
## Summary

- Fix zoxide doctor warning by moving `zoxide init` to very end of `.zshrc`
- Guard `alias cd='z'` with `CLAUDECODE` env var check so Claude Code's
  Bash tool uses builtin cd
- Add Catppuccin integrations for rainbow-delimiters and dropbar
- Add Ghostty vim-style split navigation keybinds (`cmd+alt+hjkl`)
- Enable LazyVim extras: clangd, tex, outline, mini-indentscope
- Update README and README.zh-TW with new keybindings and plugin docs

## Test plan

- [x] `bash ~/test-dotfiles.sh` — 39/39 pass
- [x] `yadm status` — clean working tree
- [ ] Open Neovim — no ibl highlight error, rainbow indent visible
- [ ] In terminal: `cd` still uses zoxide
- [ ] In Claude Code: no zoxide doctor warning on new shell