### PR TITLE
feat: Ghostty 1.3.x optimizations, git config split, and dotfiles hardening

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "opus",
+  "model": "opus[1m]",
   "hooks": {
     "Notification": [
       {
@@ -18,6 +18,28 @@
     "command": "~/.local/bin/claude-statusline"
   },
   "enabledPlugins": {
-    "lua-lsp@claude-plugins-official": true
+    "lua-lsp@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true,
+    "apify-actor-development@apify-agent-skills": true,
+    "apify-ultimate-scraper@apify-agent-skills": true,
+    "ghostty-config@ghostty-config-dev": true
+  },
+  "extraKnownMarketplaces": {
+    "apify-agent-skills": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/apify/agent-skills.git"
+      }
+    },
+    "ghostty-config-dev": {
+      "source": {
+        "source": "github",
+        "repo": "shyuan/ghostty-config-plugin"
+      }
+    }
   }
 }

--- a/.claude/skills/dotfiles-commit/SKILL.md
+++ b/.claude/skills/dotfiles-commit/SKILL.md
@@ -24,7 +24,7 @@ Before every commit, run these in order:
 2. Run markdown lint on all docs:
 
    ```bash
-   npx markdownlint-cli '**/*.md' --ignore node_modules
+   yadm ls-files '*.md' | xargs npx markdownlint-cli
    ```
 
 3. Fix ALL lint errors before proceeding — no exceptions.
@@ -93,7 +93,7 @@ yadm checkout -b feature/branch-name
 
 # Make changes, test, commit
 bash ~/test-dotfiles.sh
-npx markdownlint-cli '**/*.md' --ignore node_modules
+yadm ls-files '*.md' | xargs npx markdownlint-cli
 yadm add <files>
 yadm commit -m "feat: description"
 

--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -3,9 +3,10 @@ font-family = "Hack Nerd Font Mono"
 font-size = 14
 font-thicken = false
 adjust-cell-width = 1%
+adjust-cell-height = 2
 
 # Performance
-scrollback-limit = 10000000
+scrollback-limit = 25000000
 
 # Window settings
 window-padding-x = 10
@@ -52,6 +53,14 @@ keybind = cmd+alt+l=goto_split:right
 # Shell Integration for Claude Code
 shell-integration = detect
 shell-integration-features = sudo,title,path
+
+# Notify when commands finish in unfocused splits (great for Claude Code + split workflow)
+# Sends macOS banner notification instead of bell (1.3.0+)
+notify-on-command-finish = unfocused
+notify-on-command-finish-action = no-bell,notify
+
+# Keep zoom state when navigating between splits with Cmd+Alt+hjkl (1.3.0+)
+split-preserve-zoom = navigation
 
 # Enhanced clipboard for better Claude Code integration
 clipboard-read = allow

--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,7 +1,7 @@
 theme = "Catppuccin Mocha"
 font-family = "Maple Mono NF CN"
 font-size = 14
-font-thicken = true
+font-thicken = false
 adjust-cell-height = 2
 
 # Programming ligatures (!=→≠, =>→⇒, ->→→, >=→≥)

--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,9 +1,12 @@
 theme = "Catppuccin Mocha"
-font-family = "Hack Nerd Font Mono"
+font-family = "Maple Mono NF CN"
 font-size = 14
-font-thicken = false
-adjust-cell-width = 1%
+font-thicken = true
 adjust-cell-height = 2
+
+# Programming ligatures (!=→≠, =>→⇒, ->→→, >=→≥)
+font-feature = calt
+font-feature = liga
 
 # Performance
 scrollback-limit = 25000000

--- a/.config/git/config
+++ b/.config/git/config
@@ -1,0 +1,59 @@
+# Shared git settings (tracked by yadm, synced across machines)
+# Machine-specific settings (user, credentials) stay in ~/.gitconfig
+
+[core]
+	pager = delta
+
+[interactive]
+	diffFilter = delta --color-only
+
+[include]
+	path = ~/.config/delta/catppuccin.gitconfig
+
+[delta]
+	features = catppuccin-mocha
+	navigate = true
+	side-by-side = true
+	line-numbers = true
+
+[init]
+	defaultBranch = main
+
+[merge]
+	conflictstyle = zdiff3
+
+[push]
+	default = current
+	autoSetupRemote = true
+
+[pull]
+	rebase = true
+
+[branch]
+	sort = -committerdate
+
+[diff]
+	colorMoved = default
+	algorithm = histogram
+
+[blame]
+	coloring = highlightRecent
+
+[rerere]
+	enabled = true
+
+[column]
+	ui = auto
+
+[rebase]
+	autostash = true
+
+[fetch]
+	prune = true
+	writeCommitGraph = true
+
+[filter "lfs"]
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process
+	required = true

--- a/.config/nvim/lua/config/autocmds.lua
+++ b/.config/nvim/lua/config/autocmds.lua
@@ -9,7 +9,11 @@
 
 local function set_transparent_bg()
   local groups = { "Normal", "NormalNC", "NormalFloat", "SnacksNormal",
-    "SnacksNormalNC", "StatusLine", "StatusLineNC" }
+    "SnacksNormalNC", "StatusLine", "StatusLineNC",
+    "RenderMarkdownCode", "RenderMarkdownCodeInline",
+    "RenderMarkdownH1Bg", "RenderMarkdownH2Bg", "RenderMarkdownH3Bg",
+    "RenderMarkdownH4Bg", "RenderMarkdownH5Bg", "RenderMarkdownH6Bg",
+    "RenderMarkdownCodeLanguage" }
   for _, group in ipairs(groups) do
     vim.api.nvim_set_hl(0, group, { bg = "NONE" })
   end

--- a/.config/nvim/lua/plugins/catppuccin.lua
+++ b/.config/nvim/lua/plugins/catppuccin.lua
@@ -62,6 +62,10 @@ return {
           -- Status line
           StatusLine = { bg = "NONE" },
           StatusLineNC = { bg = "NONE" },
+
+          -- Markdown code blocks: transparent background
+          RenderMarkdownCode = { bg = "NONE" },
+          RenderMarkdownCodeInline = { bg = "NONE" },
         }
       end,
       integrations = {

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -1,4 +1,5 @@
 "$schema" = 'https://starship.rs/config-schema.json'
+command_timeout = 1000
 
 format = """
 [](red)\

--- a/.config/yazi/yazi.toml
+++ b/.config/yazi/yazi.toml
@@ -19,6 +19,13 @@ max_height = 900
 image_filter = "lanczos3"
 image_quality = 75
 
+[plugin]
+prepend_previewers = [
+	{ url = "*.md", run = "glow" },
+	{ url = "*.mdx", run = "glow" },
+	{ url = "*.markdown", run = "glow" },
+]
+
 [opener]
 edit = [
 	{ run = "${EDITOR:-nvim} \"$@\"", block = true, for = "unix" },

--- a/.ssh/config.d/00-defaults.conf
+++ b/.ssh/config.d/00-defaults.conf
@@ -10,10 +10,13 @@ Host *
     ServerAliveInterval 30
     ServerAliveCountMax 3
 
-    # SSH agent -- use local keys on remote machines
-    # Note: ForwardAgent has security implications on untrusted servers
+    # SSH agent -- add keys automatically on first use
     AddKeysToAgent yes
-    ForwardAgent yes
+    # ForwardAgent disabled globally for security (compromised server can use your keys)
+    # Enable per-host in ~/.ssh/config for trusted servers:
+    #   Host trusted-server
+    #       ForwardAgent yes
+    ForwardAgent no
 
     # Compression -- helps on slow links, negligible on fast ones
     Compression yes

--- a/Brewfile
+++ b/Brewfile
@@ -146,6 +146,7 @@ cask "arc"
 # Display management tool
 cask "betterdisplay"
 cask "font-hack-nerd-font"
+cask "font-maple-mono-nf-cn"
 # Terminal emulator that uses platform-native UI and GPU acceleration
 cask "ghostty"
 # Cross-platform Git credential storage for multiple hosting providers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,9 @@ macOS (Apple Silicon) development environment:
    Use `$HOME` instead of hardcoded user paths. Scripts must be `chmod +x`.
 
 4. **Lint-free commits** — Every commit MUST pass markdown linting.
-   Run `npx markdownlint-cli '**/*.md' --ignore node_modules` before
-   any commit. Fix ALL lint errors, no exceptions.
+   Run `yadm ls-files '*.md' | xargs npx markdownlint-cli` before
+   any commit. Fix ALL lint errors, no exceptions. Never use
+   `'**/*.md'` from `~` — it scans the entire home directory and hangs.
 
 5. **Run tests before committing** — `bash ~/test-dotfiles.sh`
 

--- a/README.md
+++ b/README.md
@@ -262,12 +262,12 @@ rm ~/Library/Logs/daily-maintenance*.log
   (`Alt+B/F/D`)
 - **Window Persistence**: Always restores window layout across restarts
   (`window-save-state = always`)
-- **Cell Width Tuning**: `adjust-cell-width = 1%` for Nerd Font icon
-  alignment
+- **Cell Tuning**: `adjust-cell-width = 1%` for Nerd Font icon
+  alignment, `adjust-cell-height = 2` for improved line spacing
 - **Prompt Navigation**: `Cmd+Up/Down` to jump between shell
   prompts in scrollback
 - **Split Zoom**: `Cmd+Shift+Enter` to maximize/restore a split
-  pane
+  pane (zoom preserved when navigating between splits)
 - **Resize Overlay**: Shows terminal dimensions while resizing
 - **Link Previews**: Hover over URLs to see previews
 - **Auto-Update**: Notifications when Ghostty updates are available
@@ -276,6 +276,8 @@ rm ~/Library/Logs/daily-maintenance*.log
 - **Desktop Notifications**: OSC 9/777 banner notifications via
   `claude-notify` hook (works in Ghostty direct, Neovim terminal,
   and SSH remote sessions)
+- **Command Finish Notifications**: macOS banner notification when
+  commands finish in unfocused splits (via `notify-on-command-finish`)
 - **Cursor Shaders**: Animated cursor effects (`cursor_slash.glsl`,
   `cursor_smear.glsl`)
 - **Config Reload**: `Cmd+Shift+,` to reload config without restart

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ rm ~/Library/Logs/daily-maintenance*.log
 
 - **Transparency**: Background opacity (0.75) with blur for macOS
   visuals
+- **Scrollback**: 25 MB scrollback buffer for long Claude Code outputs
 - **Shell Integration**: Enhanced shell integration with `sudo`,
   `title`, and `path` features (cursor feature disabled to avoid
   conflict with custom GLSL cursor shaders)
@@ -276,8 +277,9 @@ rm ~/Library/Logs/daily-maintenance*.log
 - **Desktop Notifications**: OSC 9/777 banner notifications via
   `claude-notify` hook (works in Ghostty direct, Neovim terminal,
   and SSH remote sessions)
-- **Command Finish Notifications**: macOS banner notification when
-  commands finish in unfocused splits (via `notify-on-command-finish`)
+- **Command Finish Notifications**: macOS banner notifications
+  (not just bell) when commands running 5s+ finish in unfocused
+  splits (via `notify-on-command-finish`)
 - **Cursor Shaders**: Animated cursor effects (`cursor_slash.glsl`,
   `cursor_smear.glsl`)
 - **Config Reload**: `Cmd+Shift+,` to reload config without restart

--- a/README.md
+++ b/README.md
@@ -292,7 +292,9 @@ rm ~/Library/Logs/daily-maintenance*.log
   long commands
 - **Tab-Only Titlebar**: `macos-titlebar-style = tabs` removes traffic
   lights, keeps tab bar
-- **Theme**: Catppuccin Mocha with Hack Nerd Font
+- **Font**: Maple Mono NF CN with programming ligatures (`!=`→`≠`,
+  `=>`→`⇒`) and CJK support
+- **Theme**: Catppuccin Mocha
 
 ### Ghostty Keybindings
 

--- a/daily-maintenance.sh
+++ b/daily-maintenance.sh
@@ -197,6 +197,19 @@ if command -v brew >/dev/null 2>&1; then
         echo "✗ FAILED"
         FAILED_COMMANDS+=("brew cleanup")
     fi
+
+    echo ""
+    echo "----------------------------------------"
+    echo "Task: Remove orphaned dependencies"
+    echo "Command: brew autoremove"
+    echo -n "Status: "
+
+    if brew autoremove 2>/dev/null; then
+        echo "✓ SUCCESS"
+    else
+        echo "✗ FAILED"
+        FAILED_COMMANDS+=("brew autoremove")
+    fi
 fi
 
 echo ""

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -248,7 +248,7 @@ echo -e "${YELLOW}11. Security Checks${NC}"
 
 # No secrets in yadm-tracked files
 if command -v yadm >/dev/null 2>&1; then
-    run_test "No secrets in tracked files" "[ -z \"\$(yadm list -a 2>/dev/null | xargs grep -lE '(APIKEY|SECRET_KEY|TOKEN|PASSWORD)\s*=' 2>/dev/null | grep -v 'HOMEBREW_NO_ANALYTICS' | grep -v 'test-dotfiles.sh')\" ]"
+    run_test "No secrets in tracked files" "[ -z \"\$(yadm list -a 2>/dev/null | xargs grep -lE '(APIKEY|SECRET_KEY|API_TOKEN|PRIVATE_KEY|TOKEN|PASSWORD|CREDENTIAL|AWS_SECRET)\s*=' 2>/dev/null | grep -v 'HOMEBREW_NO_ANALYTICS' | grep -v 'test-dotfiles.sh')\" ]"
 fi
 echo
 

--- a/uninstall-daily-maintenance.sh
+++ b/uninstall-daily-maintenance.sh
@@ -11,7 +11,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-PLIST_FILE="$HOME/Library/LaunchAgents/com.nickboy.daily-maintenance.plist"
+PLIST_FILE="$HOME/Library/LaunchAgents/com.daily-maintenance.plist"
 LOG_DIR="$HOME/Library/Logs"
 
 echo -e "${BLUE}========================================${NC}"
@@ -32,7 +32,7 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 fi
 
 # Unload the LaunchAgent if it's running
-if launchctl list | grep -q "com.nickboy.daily-maintenance"; then
+if launchctl list | grep -q "com.daily-maintenance"; then
     echo -e "${YELLOW}Stopping automation...${NC}"
     launchctl unload "$PLIST_FILE"
     if [ $? -eq 0 ]; then
@@ -74,7 +74,7 @@ echo
 echo "Script files are still available at:"
 echo "  • ~/daily-maintenance.sh"
 echo "  • ~/daily-maintenance-control.sh"
-echo "  • ~/Library/LaunchAgents/com.nickboy.daily-maintenance.plist"
+echo "  • ~/Library/LaunchAgents/com.daily-maintenance.plist"
 echo
 echo "To reinstall, run:"
 echo -e "  ${GREEN}bash ~/install-daily-maintenance.sh${NC}"


### PR DESCRIPTION
## Summary

- **Ghostty 1.3.x**: Add `notify-on-command-finish` (macOS banner notifications),
  `split-preserve-zoom` (keep zoom when navigating splits), `adjust-cell-height`
  (line spacing), bump scrollback to 25MB
- **Git config split**: Move shared settings to `~/.config/git/config` (tracked),
  keep machine-specific user/credentials in `~/.gitconfig` (gitignored) — enables
  `yadm pull` to sync git improvements across machines
- **Security**: Restrict SSH `ForwardAgent` from global to per-host, expand
  secret detection patterns in test suite
- **Bug fixes**: Fix plist service name mismatch in uninstall script, fix
  markdownlint glob OOM (scope to yadm-tracked files), fix README typo
- **Maintenance**: Add `brew autoremove` to daily cleanup, add starship
  `command_timeout` safety, add git `rerere`/`column.ui`/`writeCommitGraph`

## Test plan

- [x] `bash ~/test-dotfiles.sh` — 56/56 tests pass
- [x] `yadm ls-files '*.md' | xargs npx markdownlint-cli` — no lint errors
- [x] `ghostty_validate_config` — config valid
- [x] `git config --list --show-origin` — shared/machine-specific split verified
- [ ] Reload Ghostty (`Cmd+Shift+,`) and test split zoom navigation
- [ ] Test `notify-on-command-finish`: run `sleep 6` in unfocused split, verify notification