### PR TITLE
fix(tmux): transparent sesh popup + Ghostty tip channel

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -87,6 +87,7 @@ resize-overlay-duration = 750ms
 
 # Auto-update notifications
 auto-update = check
+auto-update-channel = tip
 
 # Additional features
 confirm-close-surface = false

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -16,6 +16,7 @@ set -g allow-passthrough all
 set -g window-style "bg=default"
 set -g window-active-style "bg=default"
 
+
 unbind r
 bind r source-file ~/.tmux.conf
 
@@ -111,5 +112,9 @@ bind -T off F12 \
     set -u status-style \;\
     refresh-client -S
 
-# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+# Initialize TMUX plugin manager
 run '~/.tmux/plugins/tpm/tpm'
+
+# Override Catppuccin theme popup colors for Ghostty transparency
+set -g popup-style "bg=default"
+set -g popup-border-style "fg=#6c7086"


### PR DESCRIPTION
## Summary

- Override Catppuccin theme `popup-style` after TPM init to enable
  Ghostty transparency in tmux popup windows (sesh picker, etc.)
- Switch Ghostty auto-update channel from `stable` to `tip` for
  latest main branch builds

## Test plan

- [x] `Ctrl+A` → `T` opens sesh picker with transparent background
- [x] Ghostty blur effect visible through popup
- [ ] Restart Ghostty and verify auto-update checks for `tip` channel