### PR TITLE
chore: gitignore Claude Code local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Git configuration (machine-specific)
 .gitconfig
 
+# Claude Code local settings (machine-specific permissions)
+.claude/settings.local.json
+
 .bin/assets/corona
 .config/vifm/vifminfo
 vim/plugged/


### PR DESCRIPTION
## Summary

- Add `.claude/settings.local.json` to `.gitignore` to prevent accidentally committing machine-specific Claude Code permission configs
- Identified during `/health` audit — the file contains 70+ allowed-tool entries with local paths

## Test plan

- [x] `bash ~/test-dotfiles.sh` — all 55 tests pass
- [x] `yadm ls-files '*.md' | xargs npx markdownlint-cli` — clean
- [x] Verified `settings.local.json` is not tracked by yadm
- [x] Confirmed `yadm status` no longer shows the file as untracked