### PR TITLE
feat: Zellij config, tmux which-key, and Yazi plugin updates

### DIFF
--- a/.config/yazi/init.lua
+++ b/.config/yazi/init.lua
@@ -25,3 +25,16 @@ require("git"):setup()
 -- Full border with rounded corners
 -- luacheck: globals ui
 require("full-border"):setup { type = ui.Border.ROUNDED }
+
+-- macOS Finder tags (Catppuccin Mocha colors)
+require("mactag"):setup {
+	keys = {
+		r = "Red", o = "Orange", y = "Yellow",
+		g = "Green", b = "Blue", p = "Purple",
+	},
+	colors = {
+		Red = "#f38ba8", Orange = "#fab387", Yellow = "#f9e2af",
+		Green = "#a6e3a1", Blue = "#89b4fa", Purple = "#cba6f7",
+	},
+	order = 500,
+}

--- a/.config/yazi/keymap.toml
+++ b/.config/yazi/keymap.toml
@@ -31,4 +31,14 @@ prepend_keymap = [
 
 	# compress: compress selected files
 	{ on = ["c", "a"], run = "plugin compress", desc = "Compress selected files" },
+
+	# diff: compare selected file with hovered file
+	{ on = "<C-d>", run = "plugin diff", desc = "Diff selected with hovered" },
+
+	# smart-paste: paste into hovered directory or CWD
+	{ on = "p", run = "plugin smart-paste", desc = "Paste into hovered dir or CWD" },
+
+	# mactag: macOS Finder tag management
+	{ on = ["b", "a"], run = "plugin mactag add", desc = "Tag selected files" },
+	{ on = ["b", "r"], run = "plugin mactag remove", desc = "Untag selected files" },
 ]

--- a/.config/yazi/package.toml
+++ b/.config/yazi/package.toml
@@ -48,6 +48,21 @@ use = "yazi-rs/plugins:piper"
 rev = "1962818"
 hash = "384464b6df8cb807425c521f8cd790f3"
 
+[[plugin.deps]]
+use = "yazi-rs/plugins:diff"
+rev = "1962818"
+hash = "8b1af6b5a69797ee951f2a80ce570818"
+
+[[plugin.deps]]
+use = "yazi-rs/plugins:smart-paste"
+rev = "1962818"
+hash = "3f8d49413bc8691b4c652eb417a20178"
+
+[[plugin.deps]]
+use = "yazi-rs/plugins:mactag"
+rev = "1962818"
+hash = "e617e9570226ba22d43325796f73b85"
+
 [[flavor.deps]]
 use = "yazi-rs/flavors:catppuccin-mocha"
 rev = "9511cb0"

--- a/.config/yazi/package.toml
+++ b/.config/yazi/package.toml
@@ -44,9 +44,9 @@ rev = "46a6b9f"
 hash = "771af2becc575a3f43d0542de823969d"
 
 [[plugin.deps]]
-use = "Reledia/glow"
-rev = "bd3eaa5"
-hash = "92b5c58159a51c567f82b618cee2b78"
+use = "yazi-rs/plugins:piper"
+rev = "1962818"
+hash = "384464b6df8cb807425c521f8cd790f3"
 
 [[flavor.deps]]
 use = "yazi-rs/flavors:catppuccin-mocha"

--- a/.config/yazi/yazi.toml
+++ b/.config/yazi/yazi.toml
@@ -29,6 +29,8 @@ prepend_previewers = [
 prepend_fetchers = [
 	{ id = "git", url = "*", run = "git" },
 	{ id = "git", url = "*/", run = "git" },
+	{ id = "mactag", url = "*", run = "mactag" },
+	{ id = "mactag", url = "*/", run = "mactag" },
 ]
 
 [opener]

--- a/.config/yazi/yazi.toml
+++ b/.config/yazi/yazi.toml
@@ -22,9 +22,9 @@ image_quality = 90
 
 [plugin]
 prepend_previewers = [
-	{ url = "*.md", run = "glow" },
-	{ url = "*.mdx", run = "glow" },
-	{ url = "*.markdown", run = "glow" },
+	{ url = "*.md", run = 'piper -- CLICOLOR_FORCE=1 glow -w=$w -s=dark "$1"' },
+	{ url = "*.mdx", run = 'piper -- CLICOLOR_FORCE=1 glow -w=$w -s=dark "$1"' },
+	{ url = "*.markdown", run = 'piper -- CLICOLOR_FORCE=1 glow -w=$w -s=dark "$1"' },
 ]
 prepend_fetchers = [
 	{ id = "git", url = "*", run = "git" },

--- a/.config/zellij/config.kdl
+++ b/.config/zellij/config.kdl
@@ -1,0 +1,295 @@
+keybinds clear-defaults=true {
+    locked {
+        bind "Ctrl g" { SwitchToMode "normal"; }
+    }
+    pane {
+        bind "left" { MoveFocus "left"; }
+        bind "down" { MoveFocus "down"; }
+        bind "up" { MoveFocus "up"; }
+        bind "right" { MoveFocus "right"; }
+        bind "c" { SwitchToMode "renamepane"; PaneNameInput 0; }
+        bind "d" { NewPane "down"; SwitchToMode "normal"; }
+        bind "e" { TogglePaneEmbedOrFloating; SwitchToMode "normal"; }
+        bind "f" { ToggleFocusFullscreen; SwitchToMode "normal"; }
+        bind "h" { MoveFocus "left"; }
+        bind "i" { TogglePanePinned; SwitchToMode "normal"; }
+        bind "j" { MoveFocus "down"; }
+        bind "k" { MoveFocus "up"; }
+        bind "l" { MoveFocus "right"; }
+        bind "n" { NewPane; SwitchToMode "normal"; }
+        bind "p" { SwitchFocus; }
+        bind "Ctrl p" { SwitchToMode "normal"; }
+        bind "r" { NewPane "right"; SwitchToMode "normal"; }
+        bind "s" { NewPane "stacked"; SwitchToMode "normal"; }
+        bind "w" { ToggleFloatingPanes; SwitchToMode "normal"; }
+        bind "z" { TogglePaneFrames; SwitchToMode "normal"; }
+    }
+    tab {
+        bind "left" { GoToPreviousTab; }
+        bind "down" { GoToNextTab; }
+        bind "up" { GoToPreviousTab; }
+        bind "right" { GoToNextTab; }
+        bind "1" { GoToTab 1; SwitchToMode "normal"; }
+        bind "2" { GoToTab 2; SwitchToMode "normal"; }
+        bind "3" { GoToTab 3; SwitchToMode "normal"; }
+        bind "4" { GoToTab 4; SwitchToMode "normal"; }
+        bind "5" { GoToTab 5; SwitchToMode "normal"; }
+        bind "6" { GoToTab 6; SwitchToMode "normal"; }
+        bind "7" { GoToTab 7; SwitchToMode "normal"; }
+        bind "8" { GoToTab 8; SwitchToMode "normal"; }
+        bind "9" { GoToTab 9; SwitchToMode "normal"; }
+        bind "[" { BreakPaneLeft; SwitchToMode "normal"; }
+        bind "]" { BreakPaneRight; SwitchToMode "normal"; }
+        bind "b" { BreakPane; SwitchToMode "normal"; }
+        bind "h" { GoToPreviousTab; }
+        bind "j" { GoToNextTab; }
+        bind "k" { GoToPreviousTab; }
+        bind "l" { GoToNextTab; }
+        bind "n" { NewTab; SwitchToMode "normal"; }
+        bind "r" { SwitchToMode "renametab"; TabNameInput 0; }
+        bind "s" { ToggleActiveSyncTab; SwitchToMode "normal"; }
+        bind "Ctrl t" { SwitchToMode "normal"; }
+        bind "x" { CloseTab; SwitchToMode "normal"; }
+        bind "tab" { ToggleTab; }
+    }
+    resize {
+        bind "left" { Resize "Increase left"; }
+        bind "down" { Resize "Increase down"; }
+        bind "up" { Resize "Increase up"; }
+        bind "right" { Resize "Increase right"; }
+        bind "+" { Resize "Increase"; }
+        bind "-" { Resize "Decrease"; }
+        bind "=" { Resize "Increase"; }
+        bind "H" { Resize "Decrease left"; }
+        bind "J" { Resize "Decrease down"; }
+        bind "K" { Resize "Decrease up"; }
+        bind "L" { Resize "Decrease right"; }
+        bind "h" { Resize "Increase left"; }
+        bind "j" { Resize "Increase down"; }
+        bind "k" { Resize "Increase up"; }
+        bind "l" { Resize "Increase right"; }
+        bind "Ctrl n" { SwitchToMode "normal"; }
+    }
+    move {
+        bind "left" { MovePane "left"; }
+        bind "down" { MovePane "down"; }
+        bind "up" { MovePane "up"; }
+        bind "right" { MovePane "right"; }
+        bind "h" { MovePane "left"; }
+        bind "Ctrl h" { SwitchToMode "normal"; }
+        bind "j" { MovePane "down"; }
+        bind "k" { MovePane "up"; }
+        bind "l" { MovePane "right"; }
+        bind "n" { MovePane; }
+        bind "p" { MovePaneBackwards; }
+        bind "tab" { MovePane; }
+    }
+    scroll {
+        bind "e" { EditScrollback; SwitchToMode "normal"; }
+        bind "s" { SwitchToMode "entersearch"; SearchInput 0; }
+    }
+    search {
+        bind "c" { SearchToggleOption "CaseSensitivity"; }
+        bind "n" { Search "down"; }
+        bind "o" { SearchToggleOption "WholeWord"; }
+        bind "p" { Search "up"; }
+        bind "w" { SearchToggleOption "Wrap"; }
+    }
+    session {
+        bind "a" {
+            LaunchOrFocusPlugin "zellij:about" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "normal"
+        }
+        bind "c" {
+            LaunchOrFocusPlugin "configuration" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "normal"
+        }
+        bind "l" {
+            LaunchOrFocusPlugin "zellij:layout-manager" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "normal"
+        }
+        bind "Ctrl o" { SwitchToMode "normal"; }
+        bind "p" {
+            LaunchOrFocusPlugin "plugin-manager" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "normal"
+        }
+        bind "s" {
+            LaunchOrFocusPlugin "zellij:share" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "normal"
+        }
+        bind "w" {
+            LaunchOrFocusPlugin "session-manager" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "normal"
+        }
+    }
+    shared_except "locked" {
+        bind "Alt left" { MoveFocusOrTab "left"; }
+        bind "Alt down" { MoveFocus "down"; }
+        bind "Alt up" { MoveFocus "up"; }
+        bind "Alt right" { MoveFocusOrTab "right"; }
+        bind "Alt +" { Resize "Increase"; }
+        bind "Alt -" { Resize "Decrease"; }
+        bind "Alt =" { Resize "Increase"; }
+        bind "Alt [" { PreviousSwapLayout; }
+        bind "Alt ]" { NextSwapLayout; }
+        bind "Alt f" { ToggleFloatingPanes; }
+        bind "Ctrl g" { SwitchToMode "locked"; }
+        bind "Alt h" { MoveFocusOrTab "left"; }
+        bind "Alt i" { MoveTab "left"; }
+        bind "Alt j" { MoveFocus "down"; }
+        bind "Alt k" { MoveFocus "up"; }
+        bind "Alt l" { MoveFocusOrTab "right"; }
+        bind "Alt n" { NewPane; }
+        bind "Alt o" { MoveTab "right"; }
+        bind "Alt p" { TogglePaneInGroup; }
+        bind "Alt Shift p" { ToggleGroupMarking; }
+        bind "Ctrl q" { Quit; }
+    }
+    shared_except "locked" "move" {
+        bind "Ctrl h" { SwitchToMode "move"; }
+    }
+    shared_except "locked" "session" {
+        bind "Ctrl o" { SwitchToMode "session"; }
+    }
+    shared_except "locked" "scroll" "search" "tmux" {
+        bind "Ctrl b" { SwitchToMode "tmux"; }
+    }
+    shared_except "locked" "scroll" "search" {
+        bind "Ctrl s" { SwitchToMode "scroll"; }
+    }
+    shared_except "locked" "tab" {
+        bind "Ctrl t" { SwitchToMode "tab"; }
+    }
+    shared_except "locked" "pane" {
+        bind "Ctrl p" { SwitchToMode "pane"; }
+    }
+    shared_except "locked" "resize" {
+        bind "Ctrl n" { SwitchToMode "resize"; }
+    }
+    shared_except "normal" "locked" "entersearch" {
+        bind "enter" { SwitchToMode "normal"; }
+    }
+    shared_except "normal" "locked" "entersearch" "renametab" "renamepane" {
+        bind "esc" { SwitchToMode "normal"; }
+    }
+    shared_among "pane" "tmux" {
+        bind "x" { CloseFocus; SwitchToMode "normal"; }
+    }
+    shared_among "scroll" "search" {
+        bind "PageDown" { PageScrollDown; }
+        bind "PageUp" { PageScrollUp; }
+        bind "left" { PageScrollUp; }
+        bind "down" { ScrollDown; }
+        bind "up" { ScrollUp; }
+        bind "right" { PageScrollDown; }
+        bind "Ctrl b" { PageScrollUp; }
+        bind "Ctrl c" { ScrollToBottom; SwitchToMode "normal"; }
+        bind "d" { HalfPageScrollDown; }
+        bind "Ctrl f" { PageScrollDown; }
+        bind "h" { PageScrollUp; }
+        bind "j" { ScrollDown; }
+        bind "k" { ScrollUp; }
+        bind "l" { PageScrollDown; }
+        bind "Ctrl s" { SwitchToMode "normal"; }
+        bind "u" { HalfPageScrollUp; }
+    }
+    entersearch {
+        bind "Ctrl c" { SwitchToMode "scroll"; }
+        bind "esc" { SwitchToMode "scroll"; }
+        bind "enter" { SwitchToMode "search"; }
+    }
+    renametab {
+        bind "esc" { UndoRenameTab; SwitchToMode "tab"; }
+    }
+    shared_among "renametab" "renamepane" {
+        bind "Ctrl c" { SwitchToMode "normal"; }
+    }
+    renamepane {
+        bind "esc" { UndoRenamePane; SwitchToMode "pane"; }
+    }
+    shared_among "session" "tmux" {
+        bind "d" { Detach; }
+    }
+    tmux {
+        bind "left" { MoveFocus "left"; SwitchToMode "normal"; }
+        bind "down" { MoveFocus "down"; SwitchToMode "normal"; }
+        bind "up" { MoveFocus "up"; SwitchToMode "normal"; }
+        bind "right" { MoveFocus "right"; SwitchToMode "normal"; }
+        bind "space" { NextSwapLayout; }
+        bind "\"" { NewPane "down"; SwitchToMode "normal"; }
+        bind "%" { NewPane "right"; SwitchToMode "normal"; }
+        bind "," { SwitchToMode "renametab"; }
+        bind "[" { SwitchToMode "scroll"; }
+        bind "Ctrl b" { Write 2; SwitchToMode "normal"; }
+        bind "c" { NewTab; SwitchToMode "normal"; }
+        bind "h" { MoveFocus "left"; SwitchToMode "normal"; }
+        bind "j" { MoveFocus "down"; SwitchToMode "normal"; }
+        bind "k" { MoveFocus "up"; SwitchToMode "normal"; }
+        bind "l" { MoveFocus "right"; SwitchToMode "normal"; }
+        bind "n" { GoToNextTab; SwitchToMode "normal"; }
+        bind "o" { FocusNextPane; }
+        bind "p" { GoToPreviousTab; SwitchToMode "normal"; }
+        bind "z" { ToggleFocusFullscreen; SwitchToMode "normal"; }
+    }
+}
+
+// Plugin aliases - can be used to change the implementation of Zellij
+// changing these requires a restart to take effect
+plugins {
+    about location="zellij:about"
+    compact-bar location="zellij:compact-bar"
+    configuration location="zellij:configuration"
+    filepicker location="zellij:strider" {
+        cwd "/"
+    }
+    plugin-manager location="zellij:plugin-manager"
+    session-manager location="zellij:session-manager"
+    status-bar location="zellij:status-bar"
+    strider location="zellij:strider"
+    tab-bar location="zellij:tab-bar"
+    welcome-screen location="zellij:session-manager" {
+        welcome_screen true
+    }
+}
+
+// Plugins to load in the background when a new session starts
+// eg. "file:/path/to/my-plugin.wasm"
+// eg. "https://example.com/my-plugin.wasm"
+load_plugins {
+    zellij:link
+}
+web_client {
+    font "monospace"
+}
+ 
+// Catppuccin Mocha theme
+theme "catppuccin-mocha"
+
+// No pane frames for a cleaner look
+pane_frames false
+
+// Copy to system clipboard on macOS
+copy_command "pbcopy"
+
+// Session persistence (replaces tmux-resurrect + tmux-continuum)
+session_serialization true
+serialize_pane_viewport true
+scrollback_lines_to_serialize 5000

--- a/.config/zellij/config.kdl
+++ b/.config/zellij/config.kdl
@@ -293,3 +293,10 @@ copy_command "pbcopy"
 session_serialization true
 serialize_pane_viewport true
 scrollback_lines_to_serialize 5000
+
+// Mouse behavior (new in 0.44)
+// Drag pane borders to resize, Ctrl+scroll to resize
+// Alt+click on file paths opens them in $EDITOR
+mouse_hover_effects true
+focus_follows_mouse true
+mouse_click_through true

--- a/.config/zellij/themes/catppuccin-mocha.kdl
+++ b/.config/zellij/themes/catppuccin-mocha.kdl
@@ -1,0 +1,18 @@
+// Catppuccin Mocha for Zellij — official theme from catppuccin/zellij
+// https://github.com/catppuccin/zellij
+
+themes {
+    catppuccin-mocha {
+        bg "#585b70"       // Surface2
+        fg "#cdd6f4"       // Text
+        red "#f38ba8"
+        green "#a6e3a1"
+        blue "#89b4fa"
+        yellow "#f9e2af"
+        magenta "#f5c2e7"  // Pink
+        orange "#fab387"   // Peach
+        cyan "#89dceb"     // Sky
+        black "#181825"    // Mantle
+        white "#cdd6f4"    // Text
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Library/LaunchAgents/com.daily-maintenance.plist
 # Yazi vendor files (managed by ya pkg, not yadm)
 .config/yazi/plugins/*/
 .config/yazi/flavors/*/
+
+# Zellij WASM plugins (binary, install separately)
+.config/zellij/plugins/*.wasm

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -94,7 +94,8 @@ set -g @plugin 'tmux-plugins/tmux-yank'
 
 # Which-key popup: press prefix+Space to see available shortcuts
 set -g @plugin 'Nucc/tmux-which-key'
-set -g @which-key-popup-bg '#1e1e2e'
+set -g @which-key-trigger '?'
+set -g @which-key-popup-bg 'default'
 set -g @which-key-popup-fg '#6c7086'
 
 set -g @resurrect-capture-pane-contents 'on'

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -18,7 +18,7 @@ set -g window-active-style "bg=default"
 
 
 unbind r
-bind r source-file ~/.tmux.conf
+bind r source-file ~/.tmux.conf \; display-message "Config reloaded"
 
 
 set -g prefix C-a
@@ -84,6 +84,7 @@ set -g @catppuccin_flavor 'mocha'
 set -g @catppuccin_status_modules_right "directory date_time"
 set -g @catppuccin_status_modules_left "session"
 set -g @catppuccin_status_background "none"
+set -g status-left-length 30
 set -g status-left "#{E:@catppuccin_status_session}"
 set -g status-right "#{E:@catppuccin_status_directory}#{E:@catppuccin_status_date_time}"
 set -g @plugin 'christoomey/vim-tmux-navigator'

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -92,6 +92,11 @@ set -g @plugin 'tmux-plugins/tmux-continuum' # automatically saves sessions for 
 
 set -g @plugin 'tmux-plugins/tmux-yank'
 
+# Which-key popup: press prefix+Space to see available shortcuts
+set -g @plugin 'Nucc/tmux-which-key'
+set -g @which-key-popup-bg '#1e1e2e'
+set -g @which-key-popup-fg '#6c7086'
+
 set -g @resurrect-capture-pane-contents 'on'
 set -g @continuum-restore 'on'
 

--- a/.zshrc
+++ b/.zshrc
@@ -354,6 +354,13 @@ alias sl='sesh list --icons'  # List all sessions with icons
 alias sn='sesh connect $(basename $PWD)'  # New session named after current dir
 alias sls='sesh list -t --icons'  # List only tmux sessions
 
+# Zellij shortcuts
+alias zj='zellij'
+alias zja='zellij attach'
+alias zjl='zellij list-sessions'
+alias zjk='zellij kill-session'
+alias zjd='zellij delete-session'
+
 # Git extras (in addition to OMZ git plugin)
 alias gs='git status'
 alias gd='git diff'

--- a/Brewfile
+++ b/Brewfile
@@ -49,6 +49,8 @@ brew "go"
 brew "hexyl"
 # Command-line benchmarking tool
 brew "hyperfine"
+# Lightweight JSON processor (used by tmux-which-key)
+brew "jq"
 # Fast, Dynamic Programming Language
 brew "julia"
 # Git-compatible version control system
@@ -127,6 +129,8 @@ brew "uv"
 brew "yadm"
 # Blazing fast terminal file manager written in Rust
 brew "yazi"
+# Terminal multiplexer (modern tmux alternative)
+brew "zellij"
 # Shell extension to navigate your filesystem faster
 brew "zoxide"
 # Magical shell history with sync and search

--- a/Brewfile
+++ b/Brewfile
@@ -3,6 +3,8 @@ tap "jstkdng/programs"
 brew "ast-grep"
 # Network bandwidth utilization tool
 brew "bandwhich"
+# Bourne-Again SHell, a UNIX command interpreter (v5, needed by tmux-which-key)
+brew "bash"
 # Clone of cat(1) with syntax highlighting and Git integration
 brew "bat"
 # Resource monitor (modern top/htop replacement)

--- a/Brewfile
+++ b/Brewfile
@@ -105,6 +105,8 @@ brew "tlrc"
 brew "terminal-notifier"
 # Fast fuzzy finder with built-in previews
 brew "television"
+# macOS file tagging CLI (used by yazi mactag plugin)
+brew "tag"
 # Count lines of code quickly
 brew "tokei"
 # Terminal multiplexer

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ configurations for macOS development environment.
 
 - **Shell**: Zsh configuration with zinit plugin manager and Oh-My-Zsh plugins
 - **Editor**: Neovim (LazyVim) and Zed configurations
-- **Terminal**: tmux with sesh session manager, Ghostty and Kitty configs
+- **Terminal**: Ghostty and Kitty configs (Catppuccin Mocha themed)
+- **Multiplexer**: tmux (with sesh, which-key) and Zellij (0.44+)
 - **Package Management**: Brewfile for Homebrew packages
 - **Git**: Global git configuration
 - **Modern CLI Tools**: ripgrep, bat, eza, dust, duf, btop, yazi, and more
@@ -580,6 +581,82 @@ Works seamlessly with image-capable tools:
 - **awrit**: Chromium-based terminal browser
 - **presenterm**: Markdown presentations with images
 
+## 🪟 Zellij Configuration
+
+[Zellij](https://zellij.dev/) is a modern terminal multiplexer (alternative
+to tmux) with built-in session persistence, floating/stacked panes, and a
+WASM plugin ecosystem. Configured for Zellij 0.44+.
+
+### Zellij Features
+
+- **Theme**: Catppuccin Mocha (consistent with Ghostty/tmux/Kitty)
+- **Session Persistence**: Built-in session serialization with viewport
+  and scrollback (replaces tmux-resurrect + tmux-continuum)
+- **Vim-Style Navigation**: hjkl keybindings for pane/tab/resize/move
+- **Tmux Compatibility Mode**: `Ctrl-b` prefix mode with familiar tmux
+  keybindings (`"` for horizontal split, `%` for vertical, etc.)
+- **Mouse Features (0.44)**: Drag pane borders to resize, `Ctrl+scroll`
+  to resize, `Alt+click` to open file paths in `$EDITOR`
+- **Focus Follows Mouse**: Matches Ghostty's `focus-follows-mouse`
+- **No Pane Frames**: Clean borderless look (toggle with `Ctrl-p z`)
+- **Layout Manager**: `Ctrl-o l` to save/apply/favorite layouts
+- **Session Manager**: `Ctrl-o w` for built-in session switcher
+
+### Zellij vs tmux vs Ghostty Splits
+
+| Feature | Ghostty Splits | Zellij | tmux |
+| --- | --- | --- | --- |
+| Sessions (detach/reattach) | No | Yes | Yes |
+| Survives SSH disconnect | No | Yes | Yes |
+| Session persistence | No | Built-in | Plugin |
+| Floating/stacked panes | No | Yes | No |
+| Plugin ecosystem | No | WASM | Shell |
+| Image preview (yazi) | Yes | No (no passthrough) | Yes |
+
+### Zellij Key Bindings
+
+| Keybinding | Action |
+| --- | --- |
+| `Alt+h/j/k/l` | Navigate panes/tabs |
+| `Alt+n` | New pane |
+| `Alt+f` | Toggle floating panes |
+| `Ctrl+p` | Pane mode (then h/j/k/l, n, d, r, x, z) |
+| `Ctrl+t` | Tab mode (then n, r, x, 1-9) |
+| `Ctrl+n` | Resize mode (then h/j/k/l) |
+| `Ctrl+s` | Scroll mode (then j/k, u/d, s for search) |
+| `Ctrl+o` | Session mode (w=sessions, l=layouts, p=plugins) |
+| `Ctrl+b` | Tmux mode (familiar tmux keybindings) |
+| `Ctrl+g` | Lock mode |
+| `Ctrl+q` | Quit |
+
+### Shell Aliases
+
+```bash
+zj              # zellij
+zja             # zellij attach
+zjl             # zellij list-sessions
+zjk             # zellij kill-session
+zjd             # zellij delete-session
+```
+
+### Known Limitations (0.44)
+
+- **No image passthrough**: Yazi image preview doesn't work in Zellij
+  (no Kitty graphics protocol or DCS passthrough support yet)
+- **Third-party WASM plugins**: Zellij 0.44 switched runtime from
+  wasmtime to wasmi; plugins compiled before March 2026 may not load
+  (e.g., zjstatus v0.22.0)
+
+### Configuration Files
+
+```text
+~/.config/zellij/
+├── config.kdl                    # Main config (keybindings, settings)
+├── themes/
+│   └── catppuccin-mocha.kdl      # Catppuccin Mocha theme
+└── plugins/                      # WASM plugins (gitignored)
+```
+
 ## 🖥️ Tmux Configuration
 
 ### Setup
@@ -612,6 +689,9 @@ TPM (Tmux Plugin Manager) is installed via Homebrew. After installing dotfiles:
   tmux sessions (status bar changes color to indicate)
 - **tmux-yank**: Consistent copy behavior with OSC52 fallback for
   remote sessions
+- **Which-Key**: Press `Ctrl-a + ?` for an interactive popup showing
+  all available keybindings organized by category (pane, window,
+  session, buffer, layout, git)
 
 ### Key Bindings
 
@@ -650,6 +730,7 @@ TPM (Tmux Plugin Manager) is installed via Homebrew. After installing dotfiles:
 | `Ctrl-a + {` | Move pane left |
 | `Ctrl-a + }` | Move pane right |
 | `Ctrl-a + r` | Reload tmux configuration |
+| `Ctrl-a + ?` | Which-key popup (keybinding hints) |
 | `F12` | Toggle nested tmux (for SSH sessions) |
 
 #### Seamless Navigation
@@ -1014,6 +1095,7 @@ nvim --headless '+Lazy! sync' +qa
 │   ├── nvim/          # Neovim configuration (LazyVim)
 │   ├── zed/           # Zed editor configuration
 │   ├── ghostty/       # Ghostty terminal configuration
+│   ├── zellij/        # Zellij multiplexer (config, theme)
 │   ├── yazi/          # Yazi file manager (theme, plugins, keymaps)
 │   ├── kitty/         # Kitty terminal configuration
 │   ├── bat/           # Bat themes

--- a/README.md
+++ b/README.md
@@ -991,8 +991,13 @@ written in Rust with async I/O. It supports image preview in Ghostty and Kitty.
 - **Status Bar**: Shows symlink targets and file owner:group
 - **Preview Quality**: `image_quality = 90` with `image_delay = 50` debounce
 - **Full Border**: Rounded border for polished appearance
-- **Smart Plugins**: smart-enter, smart-filter, jump-to-char,
-  toggle-pane, chmod, lazygit, compress
+- **File Diff**: diff.yazi for quick file comparison with patch
+  to clipboard
+- **Smart Paste**: Context-aware paste into hovered directories
+- **macOS Tags**: mactag.yazi for Finder color tag integration
+  (Catppuccin Mocha themed)
+- **Smart Plugins**: smart-enter, smart-filter, smart-paste,
+  jump-to-char, toggle-pane, chmod, lazygit, compress
 
 **Keybindings:**
 
@@ -1013,6 +1018,10 @@ written in Rust with async I/O. It supports image preview in Ghostty and Kitty.
 | `g` then `t` | Open Ghostty in current directory |
 | `c` then `m` | Chmod selected files |
 | `c` then `a` | Compress selected files |
+| `Ctrl+d` | Diff selected file with hovered file |
+| `p` | Smart paste (into hovered dir or CWD) |
+| `b` then `a` | Add macOS Finder tags to selected files |
+| `b` then `r` | Remove macOS Finder tags |
 
 ```bash
 # Open yazi (use 'y' wrapper to cd on exit)
@@ -1037,8 +1046,9 @@ y
 ├── package.toml   # Package manifest (ya pkg install/upgrade)
 ├── plugins/
 │   └── (all)      # Managed by ya pkg: git, smart-enter,
-│                  # smart-filter, jump-to-char, toggle-pane,
-│                  # chmod, lazygit, compress, full-border, piper
+│                  # smart-filter, smart-paste, jump-to-char,
+│                  # toggle-pane, chmod, diff, mactag, piper,
+│                  # full-border, lazygit, compress
 └── flavors/
     └── catppuccin-mocha.yazi/  # Theme flavor
 ```

--- a/README.md
+++ b/README.md
@@ -984,8 +984,8 @@ written in Rust with async I/O. It supports image preview in Ghostty and Kitty.
 
 - **Theme**: Catppuccin Mocha flavor (consistent with Ghostty/Kitty/Neovim)
 - **Git Integration**: git.yazi plugin shows git status inline next to files
-- **Markdown Preview**: glow.yazi plugin renders markdown with syntax
-  highlighting
+- **Markdown Preview**: piper.yazi with glow for rendered markdown
+  previews
 - **HiDPI Preview**: `max_width`/`max_height` set to 16384 so PDF and image
   previews fill the entire column on Retina displays
 - **Status Bar**: Shows symlink targets and file owner:group
@@ -1036,10 +1036,9 @@ y
 ├── init.lua       # Status bar, git, full-border setup
 ├── package.toml   # Package manifest (ya pkg install/upgrade)
 ├── plugins/
-│   ├── glow.yazi/ # Markdown preview with glow (manual)
-│   └── (others)   # Managed by ya pkg: git, smart-enter,
+│   └── (all)      # Managed by ya pkg: git, smart-enter,
 │                  # smart-filter, jump-to-char, toggle-pane,
-│                  # chmod, lazygit, compress, full-border
+│                  # chmod, lazygit, compress, full-border, piper
 └── flavors/
     └── catppuccin-mocha.yazi/  # Theme flavor
 ```

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -12,7 +12,8 @@
 
 - **Shell**: Zsh 搭配 zinit 外掛管理器與 Oh-My-Zsh 外掛
 - **編輯器**: Neovim (LazyVim) 與 Zed 設定
-- **終端機**: tmux 搭配 sesh 工作階段管理器、Ghostty 與 Kitty 設定
+- **終端機**: Ghostty 與 Kitty 設定（Catppuccin Mocha 主題）
+- **多工器**: tmux（搭配 sesh、which-key）與 Zellij（0.44+）
 - **套件管理**: 透過 Brewfile 管理 Homebrew 套件
 - **Git**: 全域 git 設定
 - **現代 CLI 工具**: ripgrep、bat、eza、dust、duf、btop、yazi 等

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -882,7 +882,7 @@ tv              # 開啟 television 模糊搜尋器
 
 - **主題**: Catppuccin Mocha（與 Ghostty/Kitty/Neovim 統一風格）
 - **Git 整合**: git.yazi 外掛在檔案旁顯示 git 狀態
-- **Markdown 預覽**: glow.yazi 外掛搭配語法高亮渲染 markdown
+- **Markdown 預覽**: piper.yazi 搭配 glow 渲染 markdown 預覽
 - **HiDPI 預覽**: `max_width`/`max_height` 設為 16384，PDF 和圖片
   預覽在 Retina 螢幕上佔滿整個預覽欄
 - **狀態列**: 顯示 symlink 指向路徑和檔案擁有者:群組

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -888,8 +888,11 @@ tv              # 開啟 television 模糊搜尋器
 - **狀態列**: 顯示 symlink 指向路徑和檔案擁有者:群組
 - **預覽品質**: `image_quality = 90` 搭配 `image_delay = 50` 防抖
 - **圓角邊框**: full-border 外掛提供精緻外觀
-- **智慧外掛**: smart-enter、smart-filter、jump-to-char、
-  toggle-pane、chmod、lazygit、compress
+- **檔案比較**: diff.yazi 快速比較檔案並產生 patch 到剪貼簿
+- **智慧貼上**: 自動貼到 hover 的目錄或目前目錄
+- **macOS 標籤**: mactag.yazi 整合 Finder 顏色標籤（Catppuccin 配色）
+- **智慧外掛**: smart-enter、smart-filter、smart-paste、
+  jump-to-char、toggle-pane、chmod、lazygit、compress
 
 **快捷鍵：**
 
@@ -910,6 +913,10 @@ tv              # 開啟 television 模糊搜尋器
 | `g` 再按 `t` | 在目前目錄開啟 Ghostty |
 | `c` 再按 `m` | 修改檔案權限 |
 | `c` 再按 `a` | 壓縮選取的檔案 |
+| `Ctrl+d` | 比較選取檔案與 hover 檔案 |
+| `p` | 智慧貼上（貼到 hover 的目錄或目前目錄） |
+| `b` 再按 `a` | 為選取檔案新增 macOS 標籤 |
+| `b` 再按 `r` | 移除 macOS 標籤 |
 
 ```bash
 # 開啟 yazi（使用 'y' 包裝函式，離開時 cd）


### PR DESCRIPTION
## Summary

- **Zellij 0.44**: Full config with Catppuccin Mocha theme, vim keybindings, tmux compat mode, session persistence, and 0.44 mouse features (hover, focus-follows, click-through)
- **tmux which-key**: `prefix+?` popup showing keybindings by category (Nucc/tmux-which-key), transparent background for Ghostty, reload confirmation on `prefix+r`, session name truncation fix
- **Yazi plugins**: Migrate deprecated glow.yazi to piper.yazi, add diff, smart-paste, and mactag (macOS Finder tags with Catppuccin colors)
- **Brewfile**: Add bash 5 (tmux-which-key dependency) and tag CLI (mactag dependency)
- **Docs**: Add Zellij section to README, update Yazi and tmux docs, update zh-TW README

## Commits (8)

1. `feat(zellij)`: Config + Catppuccin Mocha theme + session persistence + aliases
2. `feat(zellij)`: Enable 0.44 mouse features
3. `feat(tmux)`: Add which-key popup for keybinding discovery
4. `fix(tmux)`: Bind which-key to prefix+?, add bash to Brewfile
5. `fix(tmux)`: Show reload confirmation, fix session name truncation
6. `docs`: Add Zellij section, document tmux which-key
7. `fix(yazi)`: Replace deprecated glow.yazi with piper.yazi
8. `feat(yazi)`: Add diff, smart-paste, and mactag plugins

## Test plan

- [x] `bash ~/test-dotfiles.sh` — 55 tests passed
- [x] `yadm ls-files '*.md' | xargs npx markdownlint-cli` — no lint errors
- [x] `zellij setup --check` — CONFIG FILE: Well defined
- [x] Zellij Catppuccin Mocha theme renders correctly
- [x] tmux-which-key popup works with `prefix+?`
- [x] Yazi markdown preview with piper+glow works
- [ ] Yazi diff, smart-paste, mactag — manual verification