### PR TITLE
fix(maintenance): root-cause bob nightly upgrades, track upstream dev

### DIFF
--- a/.config/yadm/bootstrap
+++ b/.config/yadm/bootstrap
@@ -78,6 +78,31 @@ else
     echo "     Run 'cargo install --locked tree-sitter-cli' manually after installing Rust"
 fi
 
+# Install bob (Neovim version manager) from git dev branch.
+# We intentionally track upstream dev instead of Homebrew or crates.io:
+# the dev branch contains the nvim proxy permission fix (issue #241) that
+# hasn't shipped in any tagged release yet. The daily maintenance script
+# keeps bob in sync with dev via SHA-cached cargo rebuilds.
+if command -v cargo &> /dev/null; then
+    if [ ! -x "$HOME/.cargo/bin/bob" ]; then
+        echo "🤖 Installing bob from MordechaiHadad/bob dev branch..."
+        cargo install --git https://github.com/MordechaiHadad/bob \
+            --branch dev --locked \
+            || echo "  ⚠️  Failed to install bob"
+        # Seed the SHA cache so the first maintenance run is a no-op.
+        if command -v bob &> /dev/null && [ -x "$HOME/.cargo/bin/bob" ]; then
+            mkdir -p "$HOME/.cache/dotfiles"
+            git ls-remote https://github.com/MordechaiHadad/bob.git refs/heads/dev \
+                2>/dev/null | awk '{print $1}' > "$HOME/.cache/dotfiles/bob-dev-sha" \
+                || rm -f "$HOME/.cache/dotfiles/bob-dev-sha"
+        fi
+    else
+        echo "🤖 bob already installed at ~/.cargo/bin/bob"
+    fi
+else
+    echo "  ⚠️  cargo not found, skipping bob installation"
+fi
+
 # Setup tmux plugin manager
 if [ ! -d "$HOME/.tmux/plugins/tpm" ]; then
     echo "🔌 Installing tmux plugin manager..."

--- a/Brewfile
+++ b/Brewfile
@@ -137,8 +137,9 @@ brew "zoxide"
 brew "atuin"
 # GitHub command-line tool
 brew "gh"
-# Neovim version manager
-brew "bob"
+# Neovim version manager (bob) is installed from git dev branch via cargo
+# in the yadm bootstrap script. Homebrew's bob lags upstream and lacks the
+# nvim proxy permission fix for nightly upgrades. See daily-maintenance.sh.
 # Powerful, clean, object-oriented scripting language
 brew "ruby"
 # Drop in replacement for ueberzug written in C++

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Automates daily system maintenance tasks including:
 - Homebrew cask updates with greedy flag (`brew upgrade --cask --greedy`)
 - Zinit plugin updates (`zinit update --all --quiet`)
 - Oh-My-Zsh updates
+- Bob self-update from git dev branch (SHA-cached cargo rebuild, only
+  recompiles when upstream advances)
 - Bob (Neovim version manager) nightly update with legacy-dir cleanup
   (`bob install nightly` + `bob use nightly`)
 - LazyVim plugin updates (`nvim --headless '+Lazy! sync' +qa`)
@@ -1112,6 +1114,10 @@ brew upgrade --cask --greedy
 # Zinit updates (in zsh)
 zinit update --all
 
+# Bob self-update from dev branch (picks up upstream fixes before release)
+cargo install --git https://github.com/MordechaiHadad/bob \
+    --branch dev --locked --force
+
 # Bob nightly update (install is idempotent; use rewrites the proxy)
 bob install nightly && bob use nightly
 
@@ -1214,7 +1220,8 @@ copy what you need.
 - [yadm](https://yadm.io/) for dotfile management
 - [LazyVim](https://www.lazyvim.org/) for Neovim configuration
 - [zinit](https://github.com/zdharma-continuum/zinit) for Zsh plugin management
-- [bob](https://github.com/MordechaiHadad/bob) for Neovim version management
+- [bob](https://github.com/MordechaiHadad/bob) for Neovim version
+  management (tracked from the upstream `dev` branch via cargo)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Automates daily system maintenance tasks including:
 - Homebrew cask updates with greedy flag (`brew upgrade --cask --greedy`)
 - Zinit plugin updates (`zinit update --all --quiet`)
 - Oh-My-Zsh updates
-- Bob (Neovim version manager) updates (`bob update`)
+- Bob (Neovim version manager) nightly update with legacy-dir cleanup
+  (`bob install nightly` + `bob use nightly`)
 - LazyVim plugin updates (`nvim --headless '+Lazy! sync' +qa`)
 - Treesitter parser updates (`nvim --headless '+TSUpdate' +qa`)
 - Homebrew cleanup (`brew cleanup --prune=all`) - removes old versions and
@@ -1111,8 +1112,8 @@ brew upgrade --cask --greedy
 # Zinit updates (in zsh)
 zinit update --all
 
-# Bob updates
-bob update
+# Bob nightly update (install is idempotent; use rewrites the proxy)
+bob install nightly && bob use nightly
 
 # LazyVim updates (in Neovim)
 nvim --headless '+Lazy! sync' +qa

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -85,7 +85,8 @@ bash ~/install-daily-maintenance.sh
 - Homebrew cask 更新（`brew upgrade --cask --greedy`）
 - Zinit 外掛更新（`zinit update --all --quiet`）
 - Oh-My-Zsh 更新
-- Bob（Neovim 版本管理器）更新（`bob update`）
+- Bob（Neovim 版本管理器）nightly 更新與舊版目錄清理
+  （`bob install nightly` + `bob use nightly`）
 - LazyVim 外掛更新（`nvim --headless '+Lazy! sync' +qa`）
 - Treesitter parser 更新（`nvim --headless '+TSUpdate' +qa`）
 - Homebrew 清理（`brew cleanup --prune=all`）— 移除舊版本並清除快取
@@ -1006,8 +1007,8 @@ brew upgrade --cask --greedy
 # Zinit 更新（在 zsh 中）
 zinit update --all
 
-# Bob 更新
-bob update
+# Bob nightly 更新（install 具冪等性；use 會重寫 proxy）
+bob install nightly && bob use nightly
 
 # LazyVim 更新（在 Neovim 中）
 nvim --headless '+Lazy! sync' +qa

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -85,6 +85,8 @@ bash ~/install-daily-maintenance.sh
 - Homebrew cask 更新（`brew upgrade --cask --greedy`）
 - Zinit 外掛更新（`zinit update --all --quiet`）
 - Oh-My-Zsh 更新
+- Bob 自我更新：從 git dev 分支重建（SHA 快取，僅在上游推進時才重新
+  編譯）
 - Bob（Neovim 版本管理器）nightly 更新與舊版目錄清理
   （`bob install nightly` + `bob use nightly`）
 - LazyVim 外掛更新（`nvim --headless '+Lazy! sync' +qa`）
@@ -1007,6 +1009,10 @@ brew upgrade --cask --greedy
 # Zinit 更新（在 zsh 中）
 zinit update --all
 
+# Bob 自我更新：從 dev 分支取得尚未發佈的上游修正
+cargo install --git https://github.com/MordechaiHadad/bob \
+    --branch dev --locked --force
+
 # Bob nightly 更新（install 具冪等性；use 會重寫 proxy）
 bob install nightly && bob use nightly
 
@@ -1109,6 +1115,7 @@ shellcheck *.sh  # 若已透過 brew 安裝
 - [LazyVim](https://www.lazyvim.org/) — Neovim 設定
 - [zinit](https://github.com/zdharma-continuum/zinit) — Zsh 外掛管理
 - [bob](https://github.com/MordechaiHadad/bob) — Neovim 版本管理
+  （透過 cargo 追蹤上游 `dev` 分支）
 
 ---
 

--- a/daily-maintenance.sh
+++ b/daily-maintenance.sh
@@ -46,13 +46,68 @@ run_with_timeout() {
     fi
 }
 
+BOB_REPO="https://github.com/MordechaiHadad/bob"
+BOB_BRANCH="dev"
+BOB_BIN="$HOME/.cargo/bin/bob"
+BOB_SHA_CACHE="$HOME/.cache/dotfiles/bob-dev-sha"
+
+# Function to self-update Bob from its git dev branch.
+#
+# Why dev and not master/crates.io: upstream has shipped the proxy
+# permission fix (commit c18ba0a, "Changed: permissions to be write for
+# nvim proxy") on the dev branch, but not yet on master, crates.io, or
+# any tagged release. Homebrew lags the same way. We pin to dev until
+# the next release cuts.
+#
+# SHA caching: `cargo install --git --force` rebuilds every run (~1min),
+# so we short-circuit when the remote dev HEAD matches the cached SHA.
+# The cache lives at ~/.cache/dotfiles/bob-dev-sha and is seeded on the
+# first successful build. If the cache is missing we still run cargo,
+# which is the correct no-op for a fresh machine.
+update_bob_self() {
+    echo ""
+    echo "----------------------------------------"
+    echo "Task: Bob self-update (cargo git dev)"
+
+    if ! command -v cargo >/dev/null 2>&1; then
+        echo "Status: ⚠ SKIPPED (cargo not installed)"
+        return 0
+    fi
+
+    local remote_sha
+    remote_sha=$(run_with_timeout 15 git ls-remote "$BOB_REPO.git" "refs/heads/$BOB_BRANCH" 2>/dev/null | awk '{print $1}')
+    if [ -z "$remote_sha" ]; then
+        echo "Status: ⚠ SKIPPED (could not reach $BOB_REPO)"
+        return 0
+    fi
+
+    local cached_sha=""
+    [ -f "$BOB_SHA_CACHE" ] && cached_sha=$(cat "$BOB_SHA_CACHE" 2>/dev/null)
+
+    if [ -x "$BOB_BIN" ] && [ "$cached_sha" = "$remote_sha" ]; then
+        echo "Status: ✓ up to date (${remote_sha:0:7})"
+        return 0
+    fi
+
+    echo "Command: cargo install --git $BOB_REPO --branch $BOB_BRANCH --locked --force"
+    echo -n "Status: "
+    if ! run_with_timeout 300 cargo install --git "$BOB_REPO" --branch "$BOB_BRANCH" --locked --force >/dev/null 2>&1; then
+        echo "✗ FAILED"
+        FAILED_COMMANDS+=("bob self-update (cargo install)")
+        return 1
+    fi
+    mkdir -p "$(dirname "$BOB_SHA_CACHE")"
+    printf '%s\n' "$remote_sha" > "$BOB_SHA_CACHE"
+    echo "✓ built ${remote_sha:0:7}"
+}
+
 # Function to update Bob (Neovim version manager) nightly.
 #
 # Root causes this fixes:
 #   1. `bob use` writes the proxy at ~/.local/share/bob/nvim-bin/nvim
 #      with mode 555, so the NEXT `bob use` cannot overwrite it and
 #      errors with "Failed to copy file". `chmod u+w` before every
-#      `bob use` is the fix.
+#      `bob use` is the fix. (Fixed upstream on dev, kept defensively.)
 #   2. `bob update nightly` warns "nightly is not installed" when the
 #      tracked install is only a legacy hash-suffixed dir. `bob install
 #      nightly` is the idempotent replacement that works in both states.
@@ -60,7 +115,7 @@ run_with_timeout() {
 #      forever; current bob installs into a single `nightly/` dir and
 #      `bob rollback` does not need the hash dirs. GC'd unconditionally.
 update_bob_nightly() {
-    local bob_bin="/opt/homebrew/bin/bob"
+    local bob_bin="$BOB_BIN"
     local bob_dir="$HOME/.local/share/bob"
     local nvim_proxy="$bob_dir/nvim-bin/nvim"
 
@@ -111,13 +166,9 @@ update_bob_nightly() {
     echo "Command: $nvim_proxy --version"
     echo -n "Status: "
     local nvim_version
-    if ! nvim_version=$(run_with_timeout 5 "$nvim_proxy" --version 2>/dev/null | head -1); then
-        echo "✗ FAILED (nvim --version errored)"
-        FAILED_COMMANDS+=("bob: nvim verification failed")
-        return 1
-    fi
+    nvim_version=$(run_with_timeout 5 "$nvim_proxy" --version 2>/dev/null | head -1)
     if [[ "$nvim_version" != NVIM* ]]; then
-        echo "✗ FAILED (unexpected: $nvim_version)"
+        echo "✗ FAILED (unexpected: ${nvim_version:-<empty>})"
         FAILED_COMMANDS+=("bob: nvim verification failed")
         return 1
     fi
@@ -262,6 +313,7 @@ else
     echo "Warning: Oh-My-Zsh not found, skipping OMZ update"
 fi
 
+update_bob_self
 update_bob_nightly
 
 # Update yazi packages (plugins and flavors)

--- a/daily-maintenance.sh
+++ b/daily-maintenance.sh
@@ -46,6 +46,130 @@ run_with_timeout() {
     fi
 }
 
+# Function to update Bob (Neovim version manager) nightly.
+#
+# Root causes this fixes:
+#   1. `bob use` writes the proxy at ~/.local/share/bob/nvim-bin/nvim
+#      with mode 555, so the NEXT `bob use` cannot overwrite it and
+#      errors with "Failed to copy file". `chmod u+w` before every
+#      `bob use` is the fix.
+#   2. `bob update nightly` warns "nightly is not installed" when the
+#      tracked install is only a legacy hash-suffixed dir. `bob install
+#      nightly` is the idempotent replacement that works in both states.
+#   3. Legacy `nightly-<hash>/` dirs from older bob versions accumulate
+#      forever; current bob installs into a single `nightly/` dir and
+#      `bob rollback` does not need the hash dirs. GC'd unconditionally.
+update_bob_nightly() {
+    local bob_bin="/opt/homebrew/bin/bob"
+    local bob_dir="$HOME/.local/share/bob"
+    local nvim_proxy="$bob_dir/nvim-bin/nvim"
+
+    echo ""
+    echo "----------------------------------------"
+    echo "Task: Bob (Neovim version manager) nightly update"
+
+    if [ ! -x "$bob_bin" ]; then
+        echo "Status: ⚠ SKIPPED (bob not installed)"
+        return 0
+    fi
+
+    # A running nvim has the proxy binary mmap'd; overwriting it would
+    # hit ETXTBSY regardless of file permissions. Skip the whole phase
+    # rather than risk a corrupt proxy.
+    local nvim_pids
+    nvim_pids=$(pgrep -x nvim 2>/dev/null | tr '\n' ' ')
+    if [ -n "$nvim_pids" ]; then
+        echo "Status: ⚠ SKIPPED (nvim running, pids: ${nvim_pids% })"
+        return 0
+    fi
+
+    # Make the proxy writable so `bob use` can overwrite it. Bob ships
+    # it at mode 555 - this is the whole reason this function exists.
+    if [ -e "$nvim_proxy" ]; then
+        chmod u+w "$nvim_proxy" 2>/dev/null || true
+    fi
+
+    echo "Command: bob install nightly"
+    echo -n "Status: "
+    if ! "$bob_bin" install nightly >/dev/null 2>&1; then
+        echo "✗ FAILED"
+        FAILED_COMMANDS+=("bob install nightly")
+        return 1
+    fi
+    echo "✓ SUCCESS"
+
+    echo "Command: bob use nightly"
+    echo -n "Status: "
+    if ! "$bob_bin" use nightly >/dev/null 2>&1; then
+        echo "✗ FAILED"
+        FAILED_COMMANDS+=("bob use nightly")
+        return 1
+    fi
+    echo "✓ SUCCESS"
+
+    # Prove the new build actually launches via the proxy.
+    echo "Command: $nvim_proxy --version"
+    echo -n "Status: "
+    local nvim_version
+    if ! nvim_version=$(run_with_timeout 5 "$nvim_proxy" --version 2>/dev/null | head -1); then
+        echo "✗ FAILED (nvim --version errored)"
+        FAILED_COMMANDS+=("bob: nvim verification failed")
+        return 1
+    fi
+    if [[ "$nvim_version" != NVIM* ]]; then
+        echo "✗ FAILED (unexpected: $nvim_version)"
+        FAILED_COMMANDS+=("bob: nvim verification failed")
+        return 1
+    fi
+    echo "✓ $nvim_version"
+
+    # GC: remove every legacy `nightly-<hash>` dir. Current bob installs
+    # into `nightly/` only, so anything hash-suffixed is an orphan from
+    # an older bob version. We `rm -rf` directly instead of calling
+    # `bob uninstall` - tested empirically, `bob uninstall nightly-<hash>`
+    # misinterprets the name and deletes the ACTIVE nightly/ dir while
+    # reporting success. Bob reads installs from the filesystem on each
+    # invocation, so filesystem removal is the whole story.
+    #
+    # The prefix check is a belt-and-braces guard against a malformed
+    # $bob_dir. Only runs after verification passes.
+    local -a legacy=()
+    local dir
+    for dir in "$bob_dir"/nightly-*; do
+        [ -d "$dir" ] && legacy+=("$dir")
+    done
+
+    if [ "${#legacy[@]}" -eq 0 ]; then
+        return 0
+    fi
+
+    echo "Command: rm -rf legacy nightly hash-dirs (${#legacy[@]})"
+    echo -n "Status: "
+    local erased=0
+    local failed=0
+    for dir in "${legacy[@]}"; do
+        if [[ "$dir" != "$bob_dir"/nightly-* ]]; then
+            failed=$((failed + 1))
+            echo ""
+            echo "  ⚠ refusing to remove unexpected path: $dir"
+            continue
+        fi
+        if rm -rf "$dir" 2>/dev/null; then
+            erased=$((erased + 1))
+        else
+            failed=$((failed + 1))
+            echo ""
+            echo "  ⚠ could not remove $(basename "$dir")"
+        fi
+    done
+    if [ "$failed" -eq 0 ]; then
+        echo "✓ erased $erased legacy build(s)"
+    else
+        echo "⚠ erased $erased, failed $failed"
+        FAILED_COMMANDS+=("bob: GC partial ($failed failed)")
+    fi
+}
+
 # Function to run command and check status
 run_command() {
     local description="$1"
@@ -138,9 +262,7 @@ else
     echo "Warning: Oh-My-Zsh not found, skipping OMZ update"
 fi
 
-if ! run_command "Bob (Neovim version manager) update" /opt/homebrew/bin/bob update nightly; then
-    FAILED_COMMANDS+=("bob update nightly")
-fi
+update_bob_nightly
 
 # Update yazi packages (plugins and flavors)
 if command -v ya >/dev/null 2>&1; then

--- a/daily-maintenance.sh
+++ b/daily-maintenance.sh
@@ -81,8 +81,15 @@ update_bob_self() {
         return 0
     fi
 
+    # Read the cached SHA, but only trust it if it's a well-formed
+    # 40-char hex string. An empty or corrupt cache file (e.g. from a
+    # killed run, disk-full, or manual mis-edit) gets discarded so the
+    # next equality check fails cleanly and we rebuild.
     local cached_sha=""
-    [ -f "$BOB_SHA_CACHE" ] && cached_sha=$(cat "$BOB_SHA_CACHE" 2>/dev/null)
+    if [ -f "$BOB_SHA_CACHE" ]; then
+        cached_sha=$(cat "$BOB_SHA_CACHE" 2>/dev/null)
+        [[ "$cached_sha" =~ ^[0-9a-f]{40}$ ]] || cached_sha=""
+    fi
 
     if [ -x "$BOB_BIN" ] && [ "$cached_sha" = "$remote_sha" ]; then
         echo "Status: ✓ up to date (${remote_sha:0:7})"
@@ -96,8 +103,12 @@ update_bob_self() {
         FAILED_COMMANDS+=("bob self-update (cargo install)")
         return 1
     fi
+    # Atomic cache write: a kill between the open and the final byte
+    # would otherwise leave a half-written cache file that fails the
+    # hex regex on the next run (forcing a redundant rebuild).
     mkdir -p "$(dirname "$BOB_SHA_CACHE")"
-    printf '%s\n' "$remote_sha" > "$BOB_SHA_CACHE"
+    printf '%s\n' "$remote_sha" > "$BOB_SHA_CACHE.tmp" \
+        && mv "$BOB_SHA_CACHE.tmp" "$BOB_SHA_CACHE"
     echo "✓ built ${remote_sha:0:7}"
 }
 


### PR DESCRIPTION
## Summary

Fix recurring bob (Neovim version manager) nightly upgrade failures in
`daily-maintenance.sh` and migrate bob off Homebrew onto an
upstream-tracked cargo-from-git install.

## Background

The daily maintenance script was failing the bob phase with:

- `bob update nightly` → `WARN nightly is not installed` (silent no-op)
- `bob use nightly` → `ERROR Error: Failed to copy file`
- accumulating `nightly-<hash>/` dirs requiring manual `bob rm` to clean

Three independent root causes, fixed across two commits on this branch.

### Commit 1 — `fix(maintenance): root-cause bob nightly upgrade failures`

1. **Mode 555 proxy bug.** `bob use` writes
   `~/.local/share/bob/nvim-bin/nvim` with `r-xr-xr-x`, so the _next_
   `bob use` cannot overwrite it. Fix: `chmod u+w` the proxy before
   every `bob use`.
2. **Wrong verb.** `bob update nightly` only updates a tracked
   installation literally named `nightly`. When only `nightly-<hash>`
   dirs exist it silently no-ops. Fix: `bob install nightly`, which is
   idempotent in both states.
3. **Destructive uninstall.** `bob uninstall nightly-<hash>` reports
   success but deletes the _active_ `nightly/` dir. Fix: `rm -rf` the
   legacy hash dirs directly — bob reads installs from the filesystem,
   so there is no registry to sync.

Defensive extras: skip when `nvim` is running (ETXTBSY risk), verify
via `$proxy --version`, report failures through `FAILED_COMMANDS`.

### Commit 2 — `feat(maintenance): migrate bob to cargo dev branch`

Homebrew and crates.io ship v4.1.6, which still has the mode-555 bug
(upstream issue #241). The fix (commit `c18ba0a`, "Changed: permissions
to be write for nvim proxy") is on bob's `dev` branch but not yet in
any tagged release. This commit:

- Replaces the Homebrew bob formula with a cargo-from-git install
  targeting `--branch dev --locked`. Added to the yadm bootstrap so
  other machines get the same setup on `yadm clone` + bootstrap.
- Adds `update_bob_self()` to the maintenance script: `git ls-remote`
  against dev, compare against `~/.cache/dotfiles/bob-dev-sha`, and
  only run `cargo install --force` when upstream advances. Unchanged
  days are a fast no-op.
- Keeps the defensive `chmod u+w` on the proxy even though dev now
  writes it at 755 — protects against regressions and older installs.

## Test plan

- [x] Static: `bash -n` and `shellcheck` clean on both
      `daily-maintenance.sh` and `.config/yadm/bootstrap`
- [x] Live test on this machine via isolated harness:
  - `update_bob_self` with cached SHA → no-ops (`✓ up to date`)
  - `update_bob_nightly` first run → install + use + verification
    succeed; `NVIM v0.13.0-dev-104+g6b0367481c` confirmed via proxy
  - Idempotent re-run → same result, no errors
- [x] `bash ~/test-dotfiles.sh` → all checks pass
- [x] `yadm ls-files '*.md' | xargs npx markdownlint-cli` → clean
- [ ] Manual verification on other machines after `yadm pull` and
      re-running bootstrap (bootstrap short-circuits if
      `~/.cargo/bin/bob` already exists)