### PR TITLE
feat(claude): rich statusline with context bar, rate limits, git, model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,9 @@
     "superpowers@claude-plugins-official": true,
     "apify-actor-development@apify-agent-skills": true,
     "apify-ultimate-scraper@apify-agent-skills": true,
-    "ghostty-config@ghostty-config-dev": true
+    "ghostty-config@ghostty-config-dev": true,
+    "pyright-lsp@claude-plugins-official": true,
+    "obsidian@obsidian-skills": true
   },
   "extraKnownMarketplaces": {
     "apify-agent-skills": {
@@ -35,6 +37,12 @@
       "source": {
         "source": "github",
         "repo": "shyuan/ghostty-config-plugin"
+      }
+    },
+    "obsidian-skills": {
+      "source": {
+        "source": "github",
+        "repo": "kepano/obsidian-skills"
       }
     }
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,10 +13,6 @@
       }
     ]
   },
-  "statusLine": {
-    "type": "command",
-    "command": "~/.local/bin/claude-statusline"
-  },
   "enabledPlugins": {
     "lua-lsp@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,

--- a/.claude/themes/my-theme.json
+++ b/.claude/themes/my-theme.json
@@ -1,0 +1,88 @@
+{
+  "name": "my-theme",
+  "base": "dark",
+  "overrides": {
+    "text": "#cdd6f4",
+    "inverseText": "#1e1e2e",
+    "inactive": "#7f849c",
+    "inactiveShimmer": "#9399b2",
+    "subtle": "#585b70",
+
+    "background": "#94e2d5",
+    "claude": "#fab387",
+    "claudeShimmer": "#f2cdcd",
+
+    "claudeBlue_FOR_SYSTEM_SPINNER": "#89b4fa",
+    "claudeBlueShimmer_FOR_SYSTEM_SPINNER": "#b4befe",
+
+    "autoAccept": "#cba6f7",
+    "permission": "#b4befe",
+    "permissionShimmer": "#cba6f7",
+    "suggestion": "#b4befe",
+    "remember": "#b4befe",
+
+    "planMode": "#94e2d5",
+    "ide": "#74c7ec",
+    "fastMode": "#fab387",
+    "fastModeShimmer": "#f2cdcd",
+    "merged": "#cba6f7",
+
+    "promptBorder": "#585b70",
+    "promptBorderShimmer": "#7f849c",
+    "bashBorder": "#f5c2e7",
+
+    "success": "#a6e3a1",
+    "error": "#f38ba8",
+    "warning": "#f9e2af",
+    "warningShimmer": "#fab387",
+
+    "diffAdded": "#2d3d33",
+    "diffAddedDimmed": "#253128",
+    "diffAddedWord": "#a6e3a1",
+    "diffRemoved": "#4a2c38",
+    "diffRemovedDimmed": "#3a2530",
+    "diffRemovedWord": "#f38ba8",
+
+    "selectionBg": "#45475a",
+    "userMessageBackground": "#313244",
+    "userMessageBackgroundHover": "#45475a",
+    "messageActionsBackground": "#313244",
+    "bashMessageBackgroundColor": "#302d3c",
+    "memoryBackgroundColor": "#2a3340",
+
+    "rate_limit_fill": "#b4befe",
+    "rate_limit_empty": "#45475a",
+
+    "briefLabelYou": "#74c7ec",
+    "briefLabelClaude": "#fab387",
+
+    "red_FOR_SUBAGENTS_ONLY": "#f38ba8",
+    "blue_FOR_SUBAGENTS_ONLY": "#89b4fa",
+    "green_FOR_SUBAGENTS_ONLY": "#a6e3a1",
+    "yellow_FOR_SUBAGENTS_ONLY": "#f9e2af",
+    "purple_FOR_SUBAGENTS_ONLY": "#cba6f7",
+    "orange_FOR_SUBAGENTS_ONLY": "#fab387",
+    "pink_FOR_SUBAGENTS_ONLY": "#f5c2e7",
+    "cyan_FOR_SUBAGENTS_ONLY": "#74c7ec",
+
+    "professionalBlue": "#74c7ec",
+    "chromeYellow": "#f9e2af",
+    "clawd_body": "#fab387",
+    "clawd_background": "#1e1e2e",
+
+    "rainbow_red": "#f38ba8",
+    "rainbow_orange": "#fab387",
+    "rainbow_yellow": "#f9e2af",
+    "rainbow_green": "#a6e3a1",
+    "rainbow_blue": "#89b4fa",
+    "rainbow_indigo": "#b4befe",
+    "rainbow_violet": "#cba6f7",
+    "rainbow_red_shimmer": "#f2cdcd",
+    "rainbow_orange_shimmer": "#f5e0dc",
+    "rainbow_yellow_shimmer": "#f9e2af",
+    "rainbow_green_shimmer": "#94e2d5",
+    "rainbow_blue_shimmer": "#89dceb",
+    "rainbow_indigo_shimmer": "#b4befe",
+    "rainbow_violet_shimmer": "#f5c2e7"
+  }
+}

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -16,8 +16,11 @@ INPUT=$(cat)
 # -----------------------------------------------------------------------------
 # Parse stdin once
 # -----------------------------------------------------------------------------
-IFS=$'\t' read -r \
-    SESSION_ID MODEL DIR \
+# Use Unit Separator (\x1f) rather than \t because bash's `read` collapses
+# consecutive whitespace separators (tab, space), which loses empty fields.
+# \x1f is non-whitespace so `read` preserves empty fields correctly.
+IFS=$'\x1f' read -r \
+    SESSION_ID MODEL DIR EFFORT_STDIN \
     PCT_RAW COST_RAW DURATION_MS \
     FIVE_H FIVE_H_RESET \
     SEVEN_D SEVEN_D_RESET < <(
@@ -26,6 +29,7 @@ IFS=$'\t' read -r \
             (.session_id // "nosession"),
             (.model.display_name // .model.id // "Claude"),
             (.workspace.current_dir // .cwd // "."),
+            (.effort_level // .effortLevel // ""),
             (.context_window.used_percentage // 0),
             (.cost.total_cost_usd // 0),
             (.cost.total_duration_ms // 0),
@@ -33,9 +37,16 @@ IFS=$'\t' read -r \
             (.rate_limits.five_hour.resets_at // .rate_limits.five_hour.reset_at // ""),
             (.rate_limits.seven_day.used_percentage // -1),
             (.rate_limits.seven_day.resets_at // .rate_limits.seven_day.reset_at // "")
-        ] | @tsv
+        ] | map(tostring) | join("")
     ' 2>/dev/null
 )
+
+# Fall back to reading effortLevel from settings.json (Claude Code may not
+# expose it in stdin); global user setting is authoritative either way.
+EFFORT=${EFFORT_STDIN:-}
+if [ -z "$EFFORT" ] && [ -f "$HOME/.claude/settings.json" ]; then
+    EFFORT=$(jq -r '.effortLevel // empty' "$HOME/.claude/settings.json" 2>/dev/null)
+fi
 
 : "${SESSION_ID:=nosession}"
 : "${MODEL:=Claude}"
@@ -200,17 +211,38 @@ BAR_STR="$(sep)${BAR_COLOR}${BAR}${C_RESET} ${C_BOLD}${PCT}%${C_RESET} ctx"
 # -----------------------------------------------------------------------------
 # Assemble folder/branch segment
 # -----------------------------------------------------------------------------
-DIR_BASE=${DIR##*/}
-[ -z "$DIR_BASE" ] && DIR_BASE="/"
-
-DIR_STR="$(sep)📁 ${C_BLUE}${DIR_BASE}${C_RESET}"
+# Folder display: just the basename (keeps statusline compact).
+# Special-case ~ to avoid showing the literal username.
+if [ "$DIR" = "$HOME" ]; then
+    DIR_DISP="~"
+else
+    DIR_DISP=${DIR##*/}
+    [ -z "$DIR_DISP" ] && DIR_DISP="/"
+fi
+DIR_STR="$(sep)📁 ${C_BLUE}${DIR_DISP}${C_RESET}"
 [ -n "$BRANCH" ] && DIR_STR="${DIR_STR} 🌿 ${C_MAGENTA}${BRANCH}${C_RESET}"
+
+# -----------------------------------------------------------------------------
+# Effort level badge (xhigh → 🚀, high → ⚡, medium → ·, low → 🌱)
+# -----------------------------------------------------------------------------
+EFFORT_STR=""
+if [ -n "$EFFORT" ] && [ "$EFFORT" != "null" ]; then
+    case "$EFFORT" in
+        xhigh|max) EFFORT_ICON="🚀"; EFFORT_COLOR="$C_RED" ;;
+        high)      EFFORT_ICON="⚡"; EFFORT_COLOR="$C_YELLOW" ;;
+        medium|med) EFFORT_ICON="·"; EFFORT_COLOR="$C_GREEN" ;;
+        low)       EFFORT_ICON="🌱"; EFFORT_COLOR="$C_DIM" ;;
+        *)         EFFORT_ICON="⚙"; EFFORT_COLOR="$C_DIM" ;;
+    esac
+    EFFORT_STR="$(sep)${EFFORT_ICON} ${EFFORT_COLOR}${EFFORT}${C_RESET}"
+fi
 
 # -----------------------------------------------------------------------------
 # Emit single line
 # -----------------------------------------------------------------------------
-printf '🤖 %s%s%s%s💰 %s%s%s%s%s%s%s%s\n' \
+printf '🤖 %s%s%s%s%s💰 %s%s%s%s%s%s%s%s\n' \
     "$C_CYAN" "$MODEL" "$C_RESET" \
+    "$EFFORT_STR" \
     "$(sep)" \
     "$COST_COLOR" "$COST_FMT" "$C_RESET" \
     "$BURN_STR" "$DUR_STR" \

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -61,19 +61,39 @@ FIVE_H_INT=${FIVE_H%.*}
 SEVEN_D_INT=${SEVEN_D%.*}
 
 # -----------------------------------------------------------------------------
-# Colors (ANSI)
+# Colors — Catppuccin Mocha palette (24-bit truecolor) to match starship/tmux
 # -----------------------------------------------------------------------------
-C_CYAN=$'\033[36m'
-C_GREEN=$'\033[32m'
-C_YELLOW=$'\033[33m'
-C_RED=$'\033[31m'
-C_MAGENTA=$'\033[35m'
-C_BLUE=$'\033[34m'
-C_DIM=$'\033[2m'
+# shellcheck disable=SC2034  # palette kept complete for future segment styling
+C_BASE=$'\033[38;2;30;30;46m'        # base (#1e1e2e) — fg on light bg
+C_TEXT=$'\033[38;2;205;214;244m'     # text (#cdd6f4)
+C_SUBTEXT=$'\033[38;2;186;194;222m'  # subtext1 (#bac2de)
+C_OVERLAY=$'\033[38;2;127;132;156m'  # overlay1 (#7f849c) — dim
+C_SAPPHIRE=$'\033[38;2;116;199;236m' # sapphire (#74c7ec)
+C_SKY=$'\033[38;2;137;220;235m'      # sky (#89dceb)
+C_TEAL=$'\033[38;2;148;226;213m'     # teal (#94e2d5)
+C_GREEN=$'\033[38;2;166;227;161m'    # green (#a6e3a1)
+C_YELLOW=$'\033[38;2;249;226;175m'   # yellow (#f9e2af)
+C_PEACH=$'\033[38;2;250;179;135m'    # peach (#fab387)
+C_RED=$'\033[38;2;243;139;168m'      # red (#f38ba8)
+C_MAUVE=$'\033[38;2;203;166;247m'    # mauve (#cba6f7)
+C_PINK=$'\033[38;2;245;194;231m'     # pink (#f5c2e7)
+C_BLUE=$'\033[38;2;137;180;250m'     # blue (#89b4fa)
+C_LAVENDER=$'\033[38;2;180;190;254m' # lavender (#b4befe)
+
+# Backgrounds (for pill-style segments à la starship prompt)
+BG_SAPPHIRE=$'\033[48;2;116;199;236m'
+BG_SURFACE=$'\033[48;2;49;50;68m'    # surface0 (#313244)
+
+# Style
 C_BOLD=$'\033[1m'
 C_RESET=$'\033[0m'
 
-sep() { printf '%s' " ${C_DIM}│${C_RESET} "; }
+# Backwards-compat aliases for existing code paths
+C_CYAN=$C_SAPPHIRE
+C_MAGENTA=$C_PINK
+C_DIM=$C_OVERLAY
+
+sep() { printf '%s' " ${C_OVERLAY}│${C_RESET} "; }
 
 threshold_color() {
     local v=$1 low=$2 med=$3
@@ -220,7 +240,8 @@ else
     [ -z "$DIR_DISP" ] && DIR_DISP="/"
 fi
 DIR_STR="$(sep)📁 ${C_BLUE}${DIR_DISP}${C_RESET}"
-[ -n "$BRANCH" ] && DIR_STR="${DIR_STR} 🌿 ${C_MAGENTA}${BRANCH}${C_RESET}"
+# Branch gets a sapphire pill (starship-style) to make it pop
+[ -n "$BRANCH" ] && DIR_STR="${DIR_STR} ${BG_SAPPHIRE}${C_BASE}${C_BOLD} 🌿 ${BRANCH} ${C_RESET}"
 
 # -----------------------------------------------------------------------------
 # Effort level badge (xhigh → 🚀, high → ⚡, medium → ·, low → 🌱)

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Claude Code status line wrapper — 3-line rich display
+#
+# Line 1: ccusage native (session cost, 5hr block, burn rate)
+# Line 2: [Model] 📁 dir 🌿 branch │ 5h: NN% │ 7d: NN%
+# Line 3: ████████░░ NN% context (green/yellow/red by threshold)
+#
+# Performance:
+# - Git branch cached per session_id in /tmp (5s TTL)
+# - ccusage has its own internal cache
+# - Claude Code suggests refreshInterval=5s in settings.json
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+# -----------------------------------------------------------------------------
+# Line 1: ccusage
+# -----------------------------------------------------------------------------
+# ccusage native line; keep only first line so malformed input doesn't
+# bloat the statusline, and show a compact fallback if ccusage chokes.
+LINE1=$(printf '%s' "$INPUT" | ccusage statusline \
+    --visual-burn-rate emoji-text \
+    --cost-source auto 2>/dev/null | head -1)
+if [ -z "$LINE1" ] || [[ "$LINE1" == *"❌"* ]]; then
+    LINE1='⚠ ccusage error (run ccusage statusline manually to diagnose)'
+fi
+printf '%s\n' "$LINE1"
+
+# -----------------------------------------------------------------------------
+# Parse stdin once for all DIY fields (// fallback for older CC versions)
+# -----------------------------------------------------------------------------
+IFS=$'\t' read -r SESSION_ID MODEL DIR PCT_RAW FIVE_H SEVEN_D < <(
+    printf '%s' "$INPUT" | jq -r '
+        [
+            (.session_id // "nosession"),
+            (.model.display_name // .model.id // "Claude"),
+            (.workspace.current_dir // .cwd // "."),
+            (.context_window.used_percentage // 0),
+            (.rate_limits.five_hour.used_percentage // -1),
+            (.rate_limits.seven_day.used_percentage // -1)
+        ] | @tsv
+    ' 2>/dev/null
+)
+
+# Sanitize (jq may emit "null" for missing fields even with //)
+: "${SESSION_ID:=nosession}"
+: "${MODEL:=Claude}"
+: "${DIR:=.}"
+: "${PCT_RAW:=0}"
+
+# Integer percentages (strip decimals)
+PCT=${PCT_RAW%.*}
+[[ "$PCT" =~ ^[0-9]+$ ]] || PCT=0
+
+FIVE_H_INT=${FIVE_H%.*}
+SEVEN_D_INT=${SEVEN_D%.*}
+
+# -----------------------------------------------------------------------------
+# Git branch (cached per session_id)
+# -----------------------------------------------------------------------------
+GIT_CACHE="/tmp/claude-statusline-git-${SESSION_ID}"
+CACHE_TTL=5
+BRANCH=""
+
+refresh_git_cache() {
+    local branch=""
+    if command -v git >/dev/null 2>&1; then
+        branch=$(cd "$DIR" 2>/dev/null && git symbolic-ref --short HEAD 2>/dev/null || \
+                 cd "$DIR" 2>/dev/null && git rev-parse --short HEAD 2>/dev/null || echo "")
+    fi
+    printf '%s' "$branch" > "$GIT_CACHE"
+}
+
+if [ ! -f "$GIT_CACHE" ] || \
+   [ "$(( $(date +%s) - $(stat -f %m "$GIT_CACHE" 2>/dev/null || echo 0) ))" -gt "$CACHE_TTL" ]; then
+    refresh_git_cache
+fi
+BRANCH=$(cat "$GIT_CACHE" 2>/dev/null || echo "")
+
+# -----------------------------------------------------------------------------
+# Colors (ANSI)
+# -----------------------------------------------------------------------------
+C_CYAN=$'\033[36m'
+C_GREEN=$'\033[32m'
+C_YELLOW=$'\033[33m'
+C_RED=$'\033[31m'
+C_DIM=$'\033[2m'
+C_RESET=$'\033[0m'
+
+# Context bar color by threshold
+if   [ "$PCT" -ge 90 ]; then BAR_COLOR="$C_RED"
+elif [ "$PCT" -ge 70 ]; then BAR_COLOR="$C_YELLOW"
+else                         BAR_COLOR="$C_GREEN"
+fi
+
+# -----------------------------------------------------------------------------
+# Line 2: [Model] 📁 dir 🌿 branch │ 5h: NN% │ 7d: NN%
+# -----------------------------------------------------------------------------
+DIR_BASE=${DIR##*/}
+[ -z "$DIR_BASE" ] && DIR_BASE="/"
+
+LINE2="${C_CYAN}[${MODEL}]${C_RESET} 📁 ${DIR_BASE}"
+[ -n "$BRANCH" ] && LINE2="${LINE2} 🌿 ${BRANCH}"
+
+# Rate limits only if Pro/Max subscription provides them
+if [ "${FIVE_H_INT:-0}" != "-1" ] && [ -n "${FIVE_H_INT:-}" ]; then
+    LINE2="${LINE2} ${C_DIM}│${C_RESET} 5h: ${FIVE_H_INT}%"
+fi
+if [ "${SEVEN_D_INT:-0}" != "-1" ] && [ -n "${SEVEN_D_INT:-}" ]; then
+    LINE2="${LINE2} ${C_DIM}│${C_RESET} 7d: ${SEVEN_D_INT}%"
+fi
+
+printf '%b\n' "$LINE2"
+
+# -----------------------------------------------------------------------------
+# Line 3: progress bar + context %
+# -----------------------------------------------------------------------------
+BAR_WIDTH=10
+FILLED=$(( PCT * BAR_WIDTH / 100 ))
+[ "$FILLED" -gt "$BAR_WIDTH" ] && FILLED=$BAR_WIDTH
+[ "$FILLED" -lt 0 ] && FILLED=0
+EMPTY=$(( BAR_WIDTH - FILLED ))
+
+# Build bar string
+BAR=""
+for ((i = 0; i < FILLED; i++)); do BAR+="█"; done
+for ((i = 0; i < EMPTY;  i++)); do BAR+="░"; done
+
+printf '%b%s%b %d%% context\n' "$BAR_COLOR" "$BAR" "$C_RESET" "$PCT"

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -239,8 +239,8 @@ else
     DIR_DISP=${DIR##*/}
     [ -z "$DIR_DISP" ] && DIR_DISP="/"
 fi
-DIR_STR="$(sep)📁 ${C_BLUE}${DIR_DISP}${C_RESET}"
-[ -n "$BRANCH" ] && DIR_STR="${DIR_STR} 🌿 ${C_SAPPHIRE}${BRANCH}${C_RESET}"
+DIR_STR="$(sep)📁 ${C_LAVENDER}${DIR_DISP}${C_RESET}"
+[ -n "$BRANCH" ] && DIR_STR="${DIR_STR} 🌿 ${C_BLUE}${BRANCH}${C_RESET}"
 
 # -----------------------------------------------------------------------------
 # Effort level badge (xhigh → 🚀, high → ⚡, medium → ·, low → 🌱)
@@ -261,7 +261,7 @@ fi
 # Emit single line
 # -----------------------------------------------------------------------------
 printf '🤖 %s%s%s%s%s💰 %s%s%s%s%s%s%s%s\n' \
-    "$C_CYAN" "$MODEL" "$C_RESET" \
+    "$C_BLUE" "$MODEL" "$C_RESET" \
     "$EFFORT_STR" \
     "$(sep)" \
     "$COST_COLOR" "$COST_FMT" "$C_RESET" \

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -1,75 +1,152 @@
 #!/usr/bin/env bash
-# Claude Code status line wrapper — 3-line rich display
+# Claude Code status line — single-line compact display, pure DIY (no ccusage).
 #
-# Line 1: ccusage native (session cost, 5hr block, burn rate)
-# Line 2: [Model] 📁 dir 🌿 branch │ 5h: NN% │ 7d: NN%
-# Line 3: ████████░░ NN% context (green/yellow/red by threshold)
+# Layout:
+# 🤖 Model │ 💰 $cost │ 🔥 $rate/hr │ ⏱ dur │ 📁 dir 🌿 branch │ 5h:NN% ↻Hh:Mm │ 7d:NN% │ [███░░] NN%
 #
 # Performance:
-# - Git branch cached per session_id in /tmp (5s TTL)
-# - ccusage has its own internal cache
-# - Claude Code suggests refreshInterval=5s in settings.json
+# - Single jq invocation extracts all fields
+# - Git branch cached per session_id in /tmp (5s TTL), yadm fallback for ~
+# - Add "refreshInterval": 5 to ~/.claude/settings.json statusLine for auto-refresh
 
 set -uo pipefail
 
 INPUT=$(cat)
 
 # -----------------------------------------------------------------------------
-# Line 1: ccusage
+# Parse stdin once
 # -----------------------------------------------------------------------------
-# ccusage native line; keep only first line so malformed input doesn't
-# bloat the statusline, and show a compact fallback if ccusage chokes.
-LINE1=$(printf '%s' "$INPUT" | ccusage statusline \
-    --visual-burn-rate emoji-text \
-    --cost-source auto 2>/dev/null | head -1)
-if [ -z "$LINE1" ] || [[ "$LINE1" == *"❌"* ]]; then
-    LINE1='⚠ ccusage error (run ccusage statusline manually to diagnose)'
-fi
-printf '%s\n' "$LINE1"
-
-# -----------------------------------------------------------------------------
-# Parse stdin once for all DIY fields (// fallback for older CC versions)
-# -----------------------------------------------------------------------------
-IFS=$'\t' read -r SESSION_ID MODEL DIR PCT_RAW FIVE_H SEVEN_D < <(
+IFS=$'\t' read -r \
+    SESSION_ID MODEL DIR \
+    PCT_RAW COST_RAW DURATION_MS \
+    FIVE_H FIVE_H_RESET \
+    SEVEN_D SEVEN_D_RESET < <(
     printf '%s' "$INPUT" | jq -r '
         [
             (.session_id // "nosession"),
             (.model.display_name // .model.id // "Claude"),
             (.workspace.current_dir // .cwd // "."),
             (.context_window.used_percentage // 0),
+            (.cost.total_cost_usd // 0),
+            (.cost.total_duration_ms // 0),
             (.rate_limits.five_hour.used_percentage // -1),
-            (.rate_limits.seven_day.used_percentage // -1)
+            (.rate_limits.five_hour.resets_at // .rate_limits.five_hour.reset_at // ""),
+            (.rate_limits.seven_day.used_percentage // -1),
+            (.rate_limits.seven_day.resets_at // .rate_limits.seven_day.reset_at // "")
         ] | @tsv
     ' 2>/dev/null
 )
 
-# Sanitize (jq may emit "null" for missing fields even with //)
 : "${SESSION_ID:=nosession}"
 : "${MODEL:=Claude}"
 : "${DIR:=.}"
 : "${PCT_RAW:=0}"
+: "${COST_RAW:=0}"
+: "${DURATION_MS:=0}"
 
-# Integer percentages (strip decimals)
 PCT=${PCT_RAW%.*}
 [[ "$PCT" =~ ^[0-9]+$ ]] || PCT=0
-
 FIVE_H_INT=${FIVE_H%.*}
 SEVEN_D_INT=${SEVEN_D%.*}
 
 # -----------------------------------------------------------------------------
-# Git branch (cached per session_id)
+# Colors (ANSI)
+# -----------------------------------------------------------------------------
+C_CYAN=$'\033[36m'
+C_GREEN=$'\033[32m'
+C_YELLOW=$'\033[33m'
+C_RED=$'\033[31m'
+C_MAGENTA=$'\033[35m'
+C_BLUE=$'\033[34m'
+C_DIM=$'\033[2m'
+C_BOLD=$'\033[1m'
+C_RESET=$'\033[0m'
+
+sep() { printf '%s' " ${C_DIM}│${C_RESET} "; }
+
+threshold_color() {
+    local v=$1 low=$2 med=$3
+    if   [ "$v" -ge "$med" ]; then printf '%s' "$C_RED"
+    elif [ "$v" -ge "$low" ]; then printf '%s' "$C_YELLOW"
+    else                           printf '%s' "$C_GREEN"
+    fi
+}
+
+# Convert ISO 8601 or epoch reset timestamp → "Hh:Mm" human-readable remaining.
+# Returns empty string if not parseable or already expired.
+relative_reset() {
+    local ts=$1
+    [ -z "$ts" ] || [ "$ts" = "null" ] && return
+
+    local target_epoch now diff
+    if [[ "$ts" =~ ^[0-9]+$ ]]; then
+        target_epoch=$ts
+    else
+        target_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${ts%%.*}" "+%s" 2>/dev/null) || \
+        target_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "${ts%%.*}Z" "+%s" 2>/dev/null)
+    fi
+    [ -z "$target_epoch" ] && return
+
+    now=$(date +%s)
+    diff=$(( target_epoch - now ))
+    [ "$diff" -le 0 ] && return
+
+    local h=$(( diff / 3600 ))
+    local m=$(( (diff % 3600) / 60 ))
+    if [ "$h" -gt 0 ]; then
+        printf '%dh%02dm' "$h" "$m"
+    else
+        printf '%dm' "$m"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Cost / burn rate / duration
+# -----------------------------------------------------------------------------
+COST_FMT=$(printf '$%.2f' "$COST_RAW" 2>/dev/null || printf '$0.00')
+COST_COLOR=$(threshold_color "${COST_RAW%.*}" 5 20)
+
+BURN_STR=""
+if [ "$DURATION_MS" -gt 60000 ]; then
+    BURN_RATE=$(awk -v c="$COST_RAW" -v d="$DURATION_MS" 'BEGIN{
+        if (d > 0) printf "%.2f", (c / (d / 3600000))
+        else print "0.00"
+    }')
+    BURN_COLOR=$(threshold_color "${BURN_RATE%.*}" 5 15)
+    BURN_STR="$(sep)🔥 ${BURN_COLOR}\$${BURN_RATE}/hr${C_RESET}"
+fi
+
+DUR_STR=""
+if [ "$DURATION_MS" -gt 1000 ]; then
+    DUR_FMT=$(awk -v ms="$DURATION_MS" 'BEGIN{
+        s = int(ms/1000)
+        h = int(s/3600); m = int((s%3600)/60); sec = s%60
+        if (h > 0)       printf "%dh%dm", h, m
+        else if (m > 0)  printf "%dm%ds", m, sec
+        else             printf "%ds", sec
+    }')
+    DUR_STR="$(sep)⏱ ${C_DIM}${DUR_FMT}${C_RESET}"
+fi
+
+# -----------------------------------------------------------------------------
+# Git / yadm branch (cached per session_id)
 # -----------------------------------------------------------------------------
 GIT_CACHE="/tmp/claude-statusline-git-${SESSION_ID}"
 CACHE_TTL=5
-BRANCH=""
 
 refresh_git_cache() {
     local branch=""
     if command -v git >/dev/null 2>&1; then
         branch=$(cd "$DIR" 2>/dev/null && git symbolic-ref --short HEAD 2>/dev/null || \
-                 cd "$DIR" 2>/dev/null && git rev-parse --short HEAD 2>/dev/null || echo "")
+                 cd "$DIR" 2>/dev/null && git rev-parse --short HEAD 2>/dev/null)
     fi
-    printf '%s' "$branch" > "$GIT_CACHE"
+    # yadm fallback for home-dir / dotfile contexts where GIT_DIR lives elsewhere
+    if [ -z "$branch" ] && command -v yadm >/dev/null 2>&1; then
+        branch=$(yadm symbolic-ref --short HEAD 2>/dev/null || \
+                 yadm rev-parse --short HEAD 2>/dev/null)
+        [ -n "$branch" ] && branch="⚡${branch}"  # ⚡ marks yadm-managed
+    fi
+    printf '%s' "${branch:-}" > "$GIT_CACHE"
 }
 
 if [ ! -f "$GIT_CACHE" ] || \
@@ -79,42 +156,30 @@ fi
 BRANCH=$(cat "$GIT_CACHE" 2>/dev/null || echo "")
 
 # -----------------------------------------------------------------------------
-# Colors (ANSI)
+# Assemble rate-limit segment (with reset countdown)
 # -----------------------------------------------------------------------------
-C_CYAN=$'\033[36m'
-C_GREEN=$'\033[32m'
-C_YELLOW=$'\033[33m'
-C_RED=$'\033[31m'
-C_DIM=$'\033[2m'
-C_RESET=$'\033[0m'
-
-# Context bar color by threshold
-if   [ "$PCT" -ge 90 ]; then BAR_COLOR="$C_RED"
-elif [ "$PCT" -ge 70 ]; then BAR_COLOR="$C_YELLOW"
-else                         BAR_COLOR="$C_GREEN"
-fi
-
-# -----------------------------------------------------------------------------
-# Line 2: [Model] 📁 dir 🌿 branch │ 5h: NN% │ 7d: NN%
-# -----------------------------------------------------------------------------
-DIR_BASE=${DIR##*/}
-[ -z "$DIR_BASE" ] && DIR_BASE="/"
-
-LINE2="${C_CYAN}[${MODEL}]${C_RESET} 📁 ${DIR_BASE}"
-[ -n "$BRANCH" ] && LINE2="${LINE2} 🌿 ${BRANCH}"
-
-# Rate limits only if Pro/Max subscription provides them
+RL_STR=""
 if [ "${FIVE_H_INT:-0}" != "-1" ] && [ -n "${FIVE_H_INT:-}" ]; then
-    LINE2="${LINE2} ${C_DIM}│${C_RESET} 5h: ${FIVE_H_INT}%"
+    RL_COLOR=$(threshold_color "$FIVE_H_INT" 50 80)
+    reset_5h=$(relative_reset "$FIVE_H_RESET")
+    if [ -n "$reset_5h" ]; then
+        RL_STR="$(sep)5h: ${RL_COLOR}${FIVE_H_INT}%${C_RESET} ${C_DIM}↻${reset_5h}${C_RESET}"
+    else
+        RL_STR="$(sep)5h: ${RL_COLOR}${FIVE_H_INT}%${C_RESET}"
+    fi
 fi
 if [ "${SEVEN_D_INT:-0}" != "-1" ] && [ -n "${SEVEN_D_INT:-}" ]; then
-    LINE2="${LINE2} ${C_DIM}│${C_RESET} 7d: ${SEVEN_D_INT}%"
+    RL_COLOR=$(threshold_color "$SEVEN_D_INT" 50 80)
+    reset_7d=$(relative_reset "$SEVEN_D_RESET")
+    if [ -n "$reset_7d" ]; then
+        RL_STR="${RL_STR}$(sep)7d: ${RL_COLOR}${SEVEN_D_INT}%${C_RESET} ${C_DIM}↻${reset_7d}${C_RESET}"
+    else
+        RL_STR="${RL_STR}$(sep)7d: ${RL_COLOR}${SEVEN_D_INT}%${C_RESET}"
+    fi
 fi
 
-printf '%b\n' "$LINE2"
-
 # -----------------------------------------------------------------------------
-# Line 3: progress bar + context %
+# Compact context progress bar (inline)
 # -----------------------------------------------------------------------------
 BAR_WIDTH=10
 FILLED=$(( PCT * BAR_WIDTH / 100 ))
@@ -122,9 +187,31 @@ FILLED=$(( PCT * BAR_WIDTH / 100 ))
 [ "$FILLED" -lt 0 ] && FILLED=0
 EMPTY=$(( BAR_WIDTH - FILLED ))
 
-# Build bar string
+if   [ "$PCT" -ge 90 ]; then BAR_COLOR="$C_RED"
+elif [ "$PCT" -ge 70 ]; then BAR_COLOR="$C_YELLOW"
+else                         BAR_COLOR="$C_GREEN"
+fi
+
 BAR=""
 for ((i = 0; i < FILLED; i++)); do BAR+="█"; done
 for ((i = 0; i < EMPTY;  i++)); do BAR+="░"; done
+BAR_STR="$(sep)${BAR_COLOR}${BAR}${C_RESET} ${C_BOLD}${PCT}%${C_RESET} ctx"
 
-printf '%b%s%b %d%% context\n' "$BAR_COLOR" "$BAR" "$C_RESET" "$PCT"
+# -----------------------------------------------------------------------------
+# Assemble folder/branch segment
+# -----------------------------------------------------------------------------
+DIR_BASE=${DIR##*/}
+[ -z "$DIR_BASE" ] && DIR_BASE="/"
+
+DIR_STR="$(sep)📁 ${C_BLUE}${DIR_BASE}${C_RESET}"
+[ -n "$BRANCH" ] && DIR_STR="${DIR_STR} 🌿 ${C_MAGENTA}${BRANCH}${C_RESET}"
+
+# -----------------------------------------------------------------------------
+# Emit single line
+# -----------------------------------------------------------------------------
+printf '🤖 %s%s%s%s💰 %s%s%s%s%s%s%s%s\n' \
+    "$C_CYAN" "$MODEL" "$C_RESET" \
+    "$(sep)" \
+    "$COST_COLOR" "$COST_FMT" "$C_RESET" \
+    "$BURN_STR" "$DUR_STR" \
+    "$DIR_STR" "$RL_STR" "$BAR_STR"

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -240,8 +240,7 @@ else
     [ -z "$DIR_DISP" ] && DIR_DISP="/"
 fi
 DIR_STR="$(sep)📁 ${C_BLUE}${DIR_DISP}${C_RESET}"
-# Branch gets a sapphire pill (starship-style) to make it pop
-[ -n "$BRANCH" ] && DIR_STR="${DIR_STR} ${BG_SAPPHIRE}${C_BASE}${C_BOLD} 🌿 ${BRANCH} ${C_RESET}"
+[ -n "$BRANCH" ] && DIR_STR="${DIR_STR} 🌿 ${C_SAPPHIRE}${BRANCH}${C_RESET}"
 
 # -----------------------------------------------------------------------------
 # Effort level badge (xhigh → 🚀, high → ⚡, medium → ·, low → 🌱)

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ configurations for macOS development environment.
 - **Version Management**: mise (polyglot dev tool manager for node, python, etc.)
 - **Completions**: Carapace (universal command completions)
 - **SSH**: Modular `config.d/` setup with multiplexing, keepalive, and agent forwarding
-- **Claude Code**: Integrated statusline with ccusage for cost tracking,
-  desktop notifications via OSC 9/777 (works in Ghostty, Neovim, and SSH),
-  claudecode.nvim with 40% split width and diff-in-new-tab workflow
+- **Claude Code**: Rich single-line statusline (cost, burn rate, session
+  duration, model, effort level, folder, git branch, rate limits,
+  context progress bar), Catppuccin Mocha custom theme, OSC 9/777 desktop
+  notifications (works in Ghostty, Neovim, and SSH), claudecode.nvim with
+  40% split width and diff-in-new-tab workflow
 - **Git Diff View**: diffview.nvim for side-by-side diff review and file
   history browsing directly in Neovim
 - **Neovim UI Enhancements**: treesitter-context (sticky function header),
@@ -504,6 +506,70 @@ over SSH without any extra tools.
 
 The full clipboard chain: Neovim OSC52 → tmux passthrough (`all`) →
 SSH → Ghostty (`clipboard-write = allow`) → macOS clipboard.
+
+## 🧰 Claude Code Customizations
+
+### Rich Statusline
+
+`~/.local/bin/claude-statusline` (bash, shellcheck-clean) emits a single
+compact line with Catppuccin Mocha coloring:
+
+```text
+🤖 Opus 4.7 | 🚀 xhigh | 💰 $14.12 | 🔥 $4/hr | ⏱ 3h32m |
+  📁 ~ 🌿 ⚡branch | 5h: 41% | 7d: 64% ↻15h | ████░░░░░░ 44% ctx
+```
+
+Segments:
+
+- **🤖 Model** (blue) — model.display_name
+- **🚀 Effort level** (color by tier) — from `.effortLevel` in
+  `settings.local.json`, red for `xhigh`
+- **💰 Session cost** (threshold color) — `.cost.total_cost_usd`
+- **🔥 Burn rate** — computed from cost / duration
+- **⏱ Duration** (dim) — session wall clock
+- **📁 Folder** (lavender) — basename, `~` for home
+- **🌿 Branch** (blue) — `git symbolic-ref` with yadm fallback (`⚡`
+  prefix marks a yadm-managed home directory)
+- **5h / 7d** (green / yellow / red by threshold) — rate-limit usage
+  with reset countdown (`↻Hh:Mm`) when `resets_at` is provided
+- **Progress bar** (green / yellow / red at 70% / 90%) — context
+  window used percentage
+
+Performance: git branch cached under
+`/tmp/claude-statusline-git-<session_id>` with 5 s TTL; all field
+extraction runs through one `jq` invocation.
+
+### Catppuccin Mocha Theme
+
+`~/.claude/themes/my-theme.json` overrides ~70 Claude Code color tokens
+(text, borders, diffs, rainbow sequence, rate-limit bars, subagent
+swatches, etc.) to match the Ghostty / tmux / fzf Catppuccin palette.
+
+Activate once per machine:
+
+```text
+/theme my-theme
+```
+
+The selection is stored in `~/.claude.json` (runtime state, not
+yadm-tracked). The definition file is shared across machines — pulling
+the repo makes the theme *available*, not *active*.
+
+### Shared vs Machine-Local Settings
+
+Claude Code reads from both `settings.json` (yadm-tracked, shared) and
+`settings.local.json` (gitignored, per-machine). The split keeps
+sensitive or personal preferences off the shared dotfiles repo:
+
+- `~/.claude/settings.json` — model, Notification hook, enabled plugins,
+  extra marketplaces
+- `~/.claude/settings.local.json` — `statusLine` (points to
+  `claude-statusline`), `effortLevel`, permission-bypass flags,
+  `permissions.defaultMode`
+
+This is the same split pattern as `~/.gitconfig` vs
+`~/.config/git/config`: safe defaults travel via yadm; anything that
+could change the security profile of a different machine stays local.
 
 ## 🌐 Remote Development
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -21,9 +21,11 @@
 - **版本管理**: mise（多語言開發工具版本管理器）
 - **自動補全**: Carapace（通用指令自動補全）
 - **SSH**: 模組化 `config.d/` 架構，支援連線多工、keepalive 與 agent forwarding
-- **Claude Code**: 整合 ccusage 的狀態列成本追蹤，透過 OSC 9/777
-  桌面通知（支援 Ghostty、Neovim 及 SSH 遠端），claudecode.nvim
-  搭配 40% 分割寬度與 diff-in-new-tab 工作流程
+- **Claude Code**: 豐富單行狀態列（成本、燒錢速率、session 時長、
+  model、effort level、資料夾、git branch、rate limit、context 進度條）、
+  Catppuccin Mocha 自訂主題、透過 OSC 9/777 桌面通知（支援 Ghostty、
+  Neovim 及 SSH 遠端），claudecode.nvim 搭配 40% 分割寬度與 diff-in-new-tab
+  工作流程
 - **Neovim UI 增強**: treesitter-context（固定函式標頭）、
   illuminate（高亮游標下符號）、inc-rename（即時重新命名預覽）、
   自訂 ASCII 啟動畫面與平滑捲動動畫
@@ -483,6 +485,66 @@ Neovim 0.10+ 內建 OSC52 剪貼簿支援。設定檔
 
 完整剪貼簿鏈路：Neovim OSC52 → tmux passthrough（`all`）→
 SSH → Ghostty（`clipboard-write = allow`）→ macOS 剪貼簿。
+
+## Claude Code 客製化
+
+### 豐富狀態列
+
+`~/.local/bin/claude-statusline`（bash、shellcheck 乾淨）產出一條
+緊湊單行，配色為 Catppuccin Mocha：
+
+```text
+🤖 Opus 4.7 | 🚀 xhigh | 💰 $14.12 | 🔥 $4/hr | ⏱ 3h32m |
+  📁 ~ 🌿 ⚡branch | 5h: 41% | 7d: 64% ↻15h | ████░░░░░░ 44% ctx
+```
+
+各段落：
+
+- **🤖 Model**（blue）— `model.display_name`
+- **🚀 Effort level**（依等級變色）— 從 `settings.local.json` 的
+  `.effortLevel` 讀，`xhigh` 顯示紅色
+- **💰 Session 成本**（依門檻變色）— `.cost.total_cost_usd`
+- **🔥 燒錢速率**— 成本 ÷ 時長即時算
+- **⏱ 時長**（dim）— session wall clock
+- **📁 資料夾**（lavender）— basename，home 顯示 `~`
+- **🌿 Branch**（blue）— `git symbolic-ref`，yadm 後備（`⚡`
+  前綴代表 yadm 管的 home）
+- **5h / 7d**（依門檻綠 / 黃 / 紅）— rate limit 使用率，若有
+  `resets_at` 會附倒數（`↻Hh:Mm`）
+- **進度條**（70% 黃、90% 紅）— context window 使用百分比
+
+效能：git branch 快取到 `/tmp/claude-statusline-git-<session_id>`，
+TTL 5 秒；欄位擷取一次 `jq` 搞定。
+
+### Catppuccin Mocha 主題
+
+`~/.claude/themes/my-theme.json` 覆寫約 70 個 Claude Code 色彩 token
+（text、邊框、diff、彩虹序列、rate-limit bar、subagent swatch 等），
+讓 Claude Code 畫面與 Ghostty / tmux / fzf 的 Catppuccin 色盤一致。
+
+每台機器各自啟用一次：
+
+```text
+/theme my-theme
+```
+
+選擇存在 `~/.claude.json`（runtime 狀態，不進 yadm）。主題定義檔跨機共用 —
+pull 之後主題只是**可用**，不是**啟用**。
+
+### 共享 vs 機器專屬設定
+
+Claude Code 同時讀 `settings.json`（yadm 追蹤、共享）與
+`settings.local.json`（gitignore、本機專屬）。拆分能讓敏感/個人設定
+不會跑到共享 dotfiles repo：
+
+- `~/.claude/settings.json` — model、Notification hook、啟用的 plugin、
+  額外 marketplace
+- `~/.claude/settings.local.json` — `statusLine`（指向
+  `claude-statusline`）、`effortLevel`、權限 bypass flag、
+  `permissions.defaultMode`
+
+跟 `~/.gitconfig` vs `~/.config/git/config` 同樣思路：安全預設走 yadm，
+會改變其他機器安全姿態的東西留本機。
 
 ## 遠端開發
 


### PR DESCRIPTION
## Summary

Replaces the single-line ccusage wrapper with a 3-line rich status bar:

```
🤖 Opus 4.7 | 💰 $X.XX session / $X.XX block (Xh left) | 🔥 $X/hr | 🧠 N (NN%)
[Opus 4.7] 📁 myapp 🌿 feat/branch │ 5h: 34% │ 7d: 12%
█████░░░░░ 58% context                         (green → yellow → red)
```

- **Line 1**: ccusage native (session cost, 5hr block, burn rate, context tokens)
- **Line 2**: model, directory basename, git branch, rate limit percentages
- **Line 3**: 10-segment progress bar for context window, colored by threshold

## Changes

- **`~/.local/bin/claude-statusline`** — rewritten from scratch (130 LOC).
  Previously showed a \"weekly cost\" cache on line 2; replaced with richer
  per-session info. File is newly tracked by yadm (was untracked before).

## Not in this PR

- `~/.claude/settings.json` `refreshInterval: 5` — kept local only to avoid
  conflicts with unrelated WIP in that file. Users who want auto-refresh can
  add it manually:
  \`\`\`jsonc
  \"statusLine\": {
    \"type\": \"command\",
    \"command\": \"~/.local/bin/claude-statusline\",
    \"refreshInterval\": 5
  }
  \`\`\`

## Performance

- Git branch cached at `/tmp/claude-statusline-git-<session_id>` with 5s TTL
  (stable key, not PID)
- ccusage retains its own internal cache (1s refresh)
- Single `jq` call extracts 6 fields; no per-field process spawn

## Graceful degradation

- Rate-limit fields omitted if API subscription doesn't provide them
  (jq `// -1` sentinel, skipped in output)
- ccusage error → compact fallback `⚠ ccusage error (run ... to diagnose)`
- Missing context → shows 0% bar (green), not a crash
- Missing git repo → branch segment omitted

## Test plan

- [x] Shellcheck clean (warning level)
- [x] Bash syntax valid
- [x] `bash ~/test-dotfiles.sh` passes
- [ ] Manual: restart a Claude Code session, verify 3 lines render with proper colors
- [ ] Manual: verify context bar turns yellow at 70%, red at 90%
- [ ] Manual: verify git branch shows when running inside a repo
- [ ] Manual: verify script tolerates older Claude Code versions (missing rate_limits fields)