### PR TITLE
fix(claude): put statusLine back in tracked settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,11 @@
       }
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "~/.local/bin/claude-statusline",
+    "refreshInterval": 5
+  },
   "enabledPlugins": {
     "lua-lsp@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -55,6 +55,10 @@ fi
 : "${COST_RAW:=0}"
 : "${DURATION_MS:=0}"
 
+# Strip parenthetical suffix from model name (e.g. "Opus 4.7 (1M context)" → "Opus 4.7")
+# Saves horizontal space in narrow terminals.
+MODEL=${MODEL% (*}
+
 PCT=${PCT_RAW%.*}
 [[ "$PCT" =~ ^[0-9]+$ ]] || PCT=0
 FIVE_H_INT=${FIVE_H%.*}
@@ -185,6 +189,14 @@ if [ ! -f "$GIT_CACHE" ] || \
     refresh_git_cache
 fi
 BRANCH=$(cat "$GIT_CACHE" 2>/dev/null || echo "")
+
+# Truncate long branch names to keep statusline on one line in narrow terminals.
+# Preserves yadm ⚡ prefix if present.
+BRANCH_MAX=28
+if [ -n "$BRANCH" ] && [ "${#BRANCH}" -gt "$BRANCH_MAX" ]; then
+    keep=$(( BRANCH_MAX - 1 ))
+    BRANCH="${BRANCH:0:$keep}…"
+fi
 
 # -----------------------------------------------------------------------------
 # Assemble rate-limit segment (with reset countdown)


### PR DESCRIPTION
## Why

Open a fresh Claude Code session and the custom statusbar is gone.

Claude Code only merges certain fields from `~/.claude/settings.local.json` (observationally: `permissions`, `hooks`). Top-level config like `statusLine` is read from `~/.claude/settings.json` only — it silently no-ops if placed in `.local.json`.

## Fix

Move `statusLine` back into tracked `~/.claude/settings.json`. It points to `~/.local/bin/claude-statusline` which is also yadm-tracked, so both the config and the script travel together.

## Per-machine override (company / shared yadm)

If another machine wants a different statusbar, they have two options:

1. **Use their own command**: add a `statusLine` block to their local `~/.claude/settings.local.json` — may or may not override; if not, option 2.
2. **Override after pull**: edit tracked `settings.json` locally and keep the change uncommitted (or use `disableAllHooks: true` in `settings.local.json` to suppress).

## Test plan

- [x] `bash ~/test-dotfiles.sh` green
- [x] `jq -e . ~/.claude/settings.json` valid
- [ ] New Claude session shows the rich statusbar (model / cost / burn / git branch / context bar)
