### PR TITLE
feat: auto-name Claude Code sessions (SessionStart hook + tmux window naming)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,15 @@
             "command": "~/.local/bin/claude-notify"
           }
         ]
+      },
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh waiting"
+          }
+        ]
       }
     ],
     "SessionStart": [
@@ -19,6 +28,39 @@
           {
             "type": "command",
             "command": "~/.local/bin/claude-name-session"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh working"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh waiting"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh idle"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.local/bin/claude-name-session"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {

--- a/.claude/skills/dotfiles-shell/SKILL.md
+++ b/.claude/skills/dotfiles-shell/SKILL.md
@@ -105,6 +105,26 @@ sl              # List all sessions
 Inside tmux, `Ctrl-A + T` opens the advanced session switcher with:
 Tab/Shift-Tab to navigate, Ctrl-x for zoxide dirs, Ctrl-d to kill session.
 
+## Claude Code Sessions
+
+- **Auto-naming** via a `SessionStart` hook
+  (`~/.local/bin/claude-name-session`, wired in `settings.json`): sets each
+  new session's `sessionTitle` to `project/branch` (`host:project/branch`
+  over SSH) — works for every launch method (shell, nvim, ClaudeDeck, SSH).
+  Names on `startup`, and on `resume` only when still unnamed (the resume
+  payload carries `session_title`, so a manual `/rename` is never clobbered;
+  this also back-names old unnamed sessions when you resume them). Portable:
+  jq with a python3 fallback for minimal remotes.
+- **`claude()` wrapper** (`.zshrc`): decorates tmux only — renames the
+  window to `🤖 <project/branch>` and restores auto-rename on exit.
+  Subcommands and print mode pass through untouched.
+- **Find/resume sessions:** `/resume` → `Ctrl+A` (all projects), `Ctrl+W`
+  (worktrees), `Ctrl+B` (branch), `/` search, or paste a PR URL.
+  `claude --resume <name>`, `claude --continue`, `claude agents --all`.
+- **Remote (SSH + tmux):** prefer **detach (`Ctrl-a d`), not exit** — the
+  agent keeps running; reconnect with `ssht host`. Run `/resume` on the
+  remote to browse that host's sessions. F12 toggles nested tmux.
+
 ## Git Configuration (.gitconfig)
 
 - Pager: **delta** with syntax highlighting

--- a/.claude/skills/dotfiles-shell/SKILL.md
+++ b/.claude/skills/dotfiles-shell/SKILL.md
@@ -92,6 +92,9 @@ user-invocable: true
 - **tmux-resurrect** — Session persistence across restarts
 - **tmux-continuum** — Auto-save sessions
 - **Catppuccin theme** — Mocha variant
+- **tmux-claude-session-manager** — `prefix+y` launch/attach Claude for the
+  cwd; `prefix+u` fzf picker of live Claude sessions (working/waiting/idle
+  status via `scripts/state.sh` hooks + live preview)
 
 ### Session Management (sesh)
 

--- a/.local/bin/claude-name-session
+++ b/.local/bin/claude-name-session
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SessionStart hook — auto-name Claude Code sessions after their
+# project/branch so they are identifiable in /resume and the terminal/tab
+# title, no matter how they were launched (shell, claudecode.nvim,
+# ClaudeDeck, or over SSH). Reads the hook payload as JSON on stdin and
+# prints a SessionStart hookSpecificOutput with `sessionTitle` (same effect
+# as /rename).
+#
+# Naming policy (verified against the real payloads on 2.1.183):
+#   - source=startup : always name (new session, no title yet)
+#   - source=resume  : the payload carries `session_title`; name only when it
+#                      is EMPTY (rescues older, never-named sessions) — never
+#                      overwrite a title set with /rename or plan-accept
+#   - clear/compact  : skip (sessionTitle is ignored there anyway)
+#
+# Portable: no macOS-only commands; parses/emits with jq, falling back to
+# python3 on minimal remotes; if neither exists it no-ops so the session
+# still starts.
+
+have() { command -v "$1" >/dev/null 2>&1; }
+have jq || have python3 || exit 0
+
+input="$(cat)"
+
+jget() {  # $1 = top-level key
+    if have jq; then
+        printf '%s' "$input" | jq -r --arg k "$1" '.[$k] // empty'
+    else
+        printf '%s' "$input" | python3 -c \
+            'import sys,json;print(json.load(sys.stdin).get(sys.argv[1],"") or "")' "$1"
+    fi
+}
+
+emit() {  # $1 = title
+    if have jq; then
+        jq -n --arg t "$1" \
+            '{hookSpecificOutput: {hookEventName: "SessionStart", sessionTitle: $t}}'
+    else
+        python3 -c \
+            'import sys,json;print(json.dumps({"hookSpecificOutput":{"hookEventName":"SessionStart","sessionTitle":sys.argv[1]}}))' \
+            "$1"
+    fi
+}
+
+case "$(jget source)" in
+    startup) ;;
+    resume) [ -n "$(jget session_title)" ] && exit 0 ;;
+    *) exit 0 ;;
+esac
+
+cwd="$(jget cwd)"
+[ -n "$cwd" ] || cwd="$PWD"
+
+# Label = <project>[/<branch>]. The yadm-managed $HOME is not a plain git
+# repo, so fall back to yadm's branch there (mirrors claude-statusline).
+branch=""
+root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)"
+if [ -n "$root" ]; then
+    label="$(basename "$root")"
+    branch="$(git -C "$cwd" symbolic-ref --quiet --short HEAD 2>/dev/null)"
+elif [ "$cwd" = "$HOME" ]; then
+    label="home"
+    branch="$(yadm rev-parse --abbrev-ref HEAD 2>/dev/null)"
+else
+    label="$(basename "$cwd")"
+fi
+
+case "$branch" in
+    "" | main | master | trunk) ;;
+    *) label="$label/$branch" ;;
+esac
+
+if [ -n "${SSH_CONNECTION:-}" ]; then
+    host="${HOSTNAME:-$(hostname -s 2>/dev/null)}"
+    label="${host%%.*}:$label"
+fi
+
+emit "$label"

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -12,6 +12,13 @@ set -g set-clipboard on
 # DCS passthrough for image protocols and shell integration
 set -g allow-passthrough all
 
+# Forward the tmux WINDOW name (e.g. the "🤖 project" set for a Claude pane)
+# to the outer terminal's tab title — locally and over SSH. Use window_name,
+# not the pane title (#T): Claude Code rewrites the pane title with its
+# spinner, which would make the tab flicker.
+set -g set-titles on
+set -g set-titles-string "#{window_name}"
+
 # Pass modifier keys (Shift+Enter, etc.) to applications inside tmux
 set -g extended-keys on
 set -as terminal-features ',xterm-ghostty:extkeys'

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -120,6 +120,12 @@ set -g @which-key-trigger '?'
 set -g @which-key-popup-bg 'default'
 set -g @which-key-popup-fg '#6c7086'
 
+# tmux-claude-session-manager: prefix+y launches/attaches a Claude session for
+# the current dir; prefix+u opens an fzf picker of live Claude sessions with a
+# live preview and working/waiting/idle status. Status is fed by the
+# scripts/state.sh hooks wired into ~/.claude/settings.json.
+set -g @plugin 'craftzdog/tmux-claude-session-manager'
+
 set -g @resurrect-capture-pane-contents 'on'
 set -g @continuum-restore 'on'
 

--- a/.zshrc
+++ b/.zshrc
@@ -358,6 +358,66 @@ alias sl='sesh list --icons'  # List all sessions with icons
 alias sn='sesh connect $(basename $PWD)'  # New session named after current dir
 alias sls='sesh list -t --icons'  # List only tmux sessions
 
+# Claude Code launcher. The session NAME is set by the SessionStart hook
+# (~/.local/bin/claude-name-session), which names every launch method
+# (shell, claudecode.nvim, ClaudeDeck, SSH). This wrapper only decorates
+# tmux: it renames the window so a live Claude pane is identifiable, then
+# restores auto-rename when claude exits. Portable (no macOS-only commands).
+# Subcommands (agents, mcp, config, ...) and print mode pass through plainly.
+claude() {
+    local arg sub=0
+    case "$1" in
+        agents|mcp|config|setup-token|update|doctor|install|migrate-installer)
+            sub=1 ;;
+    esac
+    for arg in "$@"; do
+        case "$arg" in
+            -p|--print) sub=1 ;;
+        esac
+    done
+
+    if (( sub )) || [[ -z "$TMUX" ]]; then
+        command claude "$@"
+        return
+    fi
+
+    # Window label = <project>[/<branch>] from the git repo root. The yadm-
+    # managed $HOME is not a plain git repo, so fall back to yadm's branch
+    # there; short hostname prefix over SSH.
+    local root label branch prev prev_name ret
+    root="$(git rev-parse --show-toplevel 2>/dev/null)"
+    if [[ -n "$root" ]]; then
+        label="${root:t}"
+        branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null)"
+    elif [[ "$PWD" == "$HOME" ]]; then
+        label="home"
+        branch="$(yadm rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    else
+        label="${PWD:t}"
+        branch=""
+    fi
+    case "$branch" in
+        "" | main | master | trunk) ;;
+        *) label="$label/$branch" ;;
+    esac
+    [[ -n "$SSH_CONNECTION" ]] && label="${HOST%%.*}:$label"
+
+    prev="$(tmux display-message -p '#{automatic-rename}' 2>/dev/null)"
+    prev_name="$(tmux display-message -p '#{window_name}' 2>/dev/null)"
+    tmux set-window-option automatic-rename off >/dev/null 2>&1
+    tmux rename-window "🤖 $label" >/dev/null 2>&1
+    command claude "$@"
+    ret=$?
+    # Restore on exit: if the window had a manual name (automatic-rename was
+    # off), put that name back; otherwise re-enable tmux's auto-renaming.
+    if [[ "$prev" == "0" ]]; then
+        tmux rename-window "$prev_name" >/dev/null 2>&1
+    else
+        tmux set-window-option automatic-rename on >/dev/null 2>&1
+    fi
+    return $ret
+}
+
 # Zellij shortcuts
 alias zj='zellij'
 alias zja='zellij attach'

--- a/README.md
+++ b/README.md
@@ -806,6 +806,11 @@ TPM (Tmux Plugin Manager) is installed via Homebrew. After installing dotfiles:
 - **Which-Key**: Press `Ctrl-a + ?` for an interactive popup showing
   all available keybindings organized by category (pane, window,
   session, buffer, layout, git)
+- **Claude Session Manager**: `Ctrl-a + y` launches/attaches a Claude Code
+  session for the current directory; `Ctrl-a + u` opens an fzf picker of
+  live Claude sessions with working/waiting/idle status and a live preview
+  (`craftzdog/tmux-claude-session-manager`; status fed by `state.sh` hooks
+  wired in `~/.claude/settings.json`)
 
 ### Key Bindings
 
@@ -846,6 +851,8 @@ TPM (Tmux Plugin Manager) is installed via Homebrew. After installing dotfiles:
 | `Ctrl-a + r` | Reload tmux configuration |
 | `Ctrl-a + ?` | Which-key popup (keybinding hints) |
 | `Ctrl-a + F` | Highlight URLs/hashes/paths (tmux-thumbs) |
+| `Ctrl-a + y` | Launch/attach Claude session for current dir |
+| `Ctrl-a + u` | Claude session picker (status + live preview) |
 | `F12` | Toggle nested tmux (for SSH sessions) |
 
 #### Seamless Navigation

--- a/README.md
+++ b/README.md
@@ -571,6 +571,42 @@ This is the same split pattern as `~/.gitconfig` vs
 `~/.config/git/config`: safe defaults travel via yadm; anything that
 could change the security profile of a different machine stays local.
 
+### Finding & Resuming Claude Sessions
+
+Claude Code already ships cross-project session discovery — the trick is
+naming sessions so they are recognizable later. A `SessionStart` hook
+(`~/.local/bin/claude-name-session`, wired in `settings.json`) auto-sets
+each new session's title from its project and branch (`project/branch`;
+`host:project/branch` over SSH) — the same effect as `/rename` — so naming
+works no matter how Claude is launched (shell, claudecode.nvim, ClaudeDeck,
+or over SSH) and shows up in the prompt box, the `/resume` picker, and the
+terminal/tab title. The `claude()` shell wrapper additionally renames the
+tmux window to `🤖 <project/branch>` (restored to auto-rename on exit) so
+live Claude panes are identifiable in the status bar.
+
+**Local discovery:**
+
+- `/resume` opens the picker — `Ctrl+A` widens it to **all projects**,
+  `Ctrl+W` to all worktrees, `Ctrl+B` filters by branch, `/` searches by
+  text, and pasting a PR URL finds the session that created it.
+- `claude --resume <name>` resumes by name; `claude --continue` resumes
+  the most recent conversation in the current directory.
+- `claude agents --all` lists running, blocked, and completed sessions.
+- `/rename` renames the active session (accepting a plan auto-names it).
+
+**Remote (SSH + tmux):**
+
+- **Detach, don't exit.** Run `claude` in a remote tmux window and leave
+  with `Ctrl-a d` — Claude keeps running. Reconnect with `ssht host` and
+  you land exactly where you left off (ControlMaster makes reconnect
+  instant; resurrect/continuum survive a tmux server restart).
+- The wrapper names the remote window `🤖 host:project` so nested tmux
+  views stay unambiguous; press **F12** to toggle the outer tmux.
+- To find an exited remote session, run `/resume` → `Ctrl+A` on the
+  remote (it reads that host's `~/.claude/projects`).
+- `claude-notify` (OSC 9/777) and OSC52 clipboard already bridge
+  notifications and copy back to Ghostty.
+
 ## 🌐 Remote Development
 
 ### Shell TERM Handling

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -700,6 +700,10 @@ TPM（Tmux Plugin Manager）透過 Homebrew 安裝。安裝 dotfiles 後：
 - **tmux-thumbs**: 按 `prefix + F` 將畫面上的 URL / commit hash /
   檔案路徑覆蓋字母標示，輸入字母即複製到剪貼簿；大寫字母會
   複製後透過 `open` 開啟 URL
+- **Claude Session Manager**: `Ctrl-a + y` 啟動/接上當前目錄的 Claude Code
+  工作階段；`Ctrl-a + u` 開啟 live Claude session 的 fzf 選單，含
+  working/waiting/idle 狀態與即時預覽（`craftzdog/tmux-claude-session-manager`；
+  狀態由接進 `~/.claude/settings.json` 的 `state.sh` hook 提供）
 
 ### 按鍵綁定
 
@@ -739,6 +743,8 @@ TPM（Tmux Plugin Manager）透過 Homebrew 安裝。安裝 dotfiles 後：
 | `Ctrl-a + }` | 向右移動窗格 |
 | `Ctrl-a + r` | 重載 tmux 設定 |
 | `Ctrl-a + F` | 高亮畫面上的 URL/hash/路徑（tmux-thumbs） |
+| `Ctrl-a + y` | 啟動/接上當前目錄的 Claude session |
+| `Ctrl-a + u` | Claude session 選單（狀態+即時預覽） |
 | `F12` | 切換巢狀 tmux（用於 SSH 工作階段） |
 
 #### 無縫導航

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -546,6 +546,40 @@ Claude Code 同時讀 `settings.json`（yadm 追蹤、共享）與
 跟 `~/.gitconfig` vs `~/.config/git/config` 同樣思路：安全預設走 yadm，
 會改變其他機器安全姿態的東西留本機。
 
+### 尋找與恢復 Claude 工作階段
+
+Claude Code 本身已內建跨專案的工作階段探索 — 關鍵在於替工作階段命名,
+事後才認得出來。`SessionStart` hook(`~/.local/bin/claude-name-session`,
+掛在 `settings.json`)會依專案與分支(`專案/分支`;SSH 時 `host:專案/分支`)
+自動設定每個新工作階段的標題(效果等同 `/rename`),所以**不論用哪種方式
+啟動**(終端、claudecode.nvim、ClaudeDeck、SSH)都會命名,並顯示在 prompt
+列、`/resume` 選單、以及終端機/分頁標題。`.zshrc` 的 `claude()` 包裝函式
+則額外把 tmux 視窗改名為 `🤖 <專案/分支>`(離開時恢復自動命名),讓執行中
+的 Claude pane 在狀態列一眼可辨。
+
+**本機探索:**
+
+- `/resume` 開啟選單 — `Ctrl+A` 擴展到**所有專案**,`Ctrl+W` 到所有
+  worktree,`Ctrl+B` 依分支過濾,`/` 依文字搜尋,貼上 PR URL 可找到
+  建立該工作階段的 session。
+- `claude --resume <名稱>` 依名稱恢復;`claude --continue` 恢復當前
+  目錄最近的對話。
+- `claude agents --all` 列出執行中、阻塞中、已完成的工作階段。
+- `/rename` 替進行中的工作階段改名(接受 plan 時會自動命名)。
+
+**遠端(SSH + tmux):**
+
+- **用 detach,不要 exit。** 在遠端 tmux 視窗裡跑 `claude`,離開時按
+  `Ctrl-a d` — Claude 會繼續執行。用 `ssht host` 重連即可回到原處
+  (ControlMaster 讓重連幾乎瞬間;resurrect/continuum 撐過 tmux server
+  重啟)。
+- 包裝函式會把遠端視窗命名為 `🤖 host:專案`,讓巢狀 tmux 不混淆;
+  按 **F12** 切換外層 tmux。
+- 要找已退出的遠端工作階段,在遠端執行 `/resume` → `Ctrl+A`
+  (它讀的是該主機的 `~/.claude/projects`)。
+- `claude-notify`(OSC 9/777)與 OSC52 剪貼簿已把通知與複製橋接回
+  Ghostty。
+
 ## 遠端開發
 
 ### Shell TERM 處理


### PR DESCRIPTION
## Summary

Give every Claude Code session a meaningful name at creation, and label the
live tmux window / terminal tab, so past sessions are easy to find via the
built-in `/resume` → `Ctrl+A` picker (now searchable by name). Leans on
built-ins — no custom finder. Works across all launch methods (shell,
claudecode.nvim, ClaudeDeck) and over SSH.

## Problem

Sessions were created **unnamed**, so the `/resume` picker only showed
auto-summaries and old sessions were hard to re-find (~79 unnamed sessions
across 9 projects). The cross-project picker already existed; it just had
nothing readable to match on.

## What changed

| File | Change |
| --- | --- |
| `.local/bin/claude-name-session` (new) | SessionStart hook: sets `sessionTitle` = `project/branch` (`host:project/branch` over SSH) |
| `.claude/settings.json` | Registers the SessionStart hook (alongside Notification; coexists with the machine-local ClaudeDeck hook) |
| `.zshrc` | `claude()` wrapper: renames the live tmux window `🤖 project/branch`, restores on exit |
| `.tmux.conf` | `set-titles on` + `set-titles-string "#{window_name}"` (forward window name → terminal tab) |
| `README.md`, `README.zh-TW.md`, dotfiles-shell skill | Document `/resume` Ctrl+A + remote detach-not-exit workflow |

## Design decisions

- **Hook names; wrapper only decorates.** The hook fires for *every* launch
  method, so naming is universal. The wrapper touches tmux only for a
  dedicated shell pane — renaming the window inside the hook would mislabel
  claudecode.nvim's window and can't restore on exit.
- **Naming policy (verified against real 2.1.183 payloads):**
  - `startup` → always name.
  - `resume` → name only if `session_title` is empty → **back-names the ~79
    old unnamed sessions when you resume them**, and never overwrites a
    `/rename` / plan-accept name. (The resume payload carries `session_title`;
    startup does not.)
  - `clear` / `compact` → skip.
- **`#{window_name}`, not `#T`.** Claude rewrites the *pane* title with its
  spinner; the stable window name avoids tab-title flicker.
- **yadm fallback.** `$HOME` is yadm-managed (not a plain git repo), so plain
  `git` sees no branch there — fall back to `yadm rev-parse` (mirrors
  `claude-statusline`). e.g. `home/feature/claude-session-naming`.
- **Portable.** No macOS-only commands; hook parses/emits with jq and falls
  back to python3 for minimal remotes; no-ops (session still starts) if
  neither exists.

## Verification

- `shellcheck` clean · `zsh -n` clean · `beautysh --check` clean ·
  `markdownlint` clean · `test-dotfiles.sh` 54/54.
- Naming-policy unit tests: startup→named; resume+existing→skip;
  resume+empty→back-named; clear→skip.
- **Real interactive Claude in an isolated tmux**: window became
  `🤖 home/feature/claude-session-naming`; resolved tab title identical;
  `automatic-rename` restored on clean exit.
- python3 fallback emits valid JSON with jq off PATH.
- Wrapper restores a hand-set window name (`build` → `🤖 …` → `build`).
- No Ghostty change required (tmux `set-titles` forwards the name; bare tabs
  get it from Claude's own OS-title).

## Open items / how we might address

1. **Resume back-naming uses the _current_ cwd's project/branch.** If you
   resume an old session from a different directory, the back-name reflects
   where you are now, not where it ran. Acceptable; flagging for review.
2. **ClaudeDeck over SSH** (out of scope): the daemon is local and can't see
   remote session state, so the permission-key relay won't work for remote
   sessions (jump-to-tab still does). Future: run the daemon on the remote,
   or `sshfs`-mount `~/.claude`.
3. **Not included (optional):** pane-command-gated in-hook rename to also
   label ClaudeDeck-launched panes — skipped because those panes can't be
   restored on exit.
4. **Excluded from this PR:** three unrelated pre-existing working-tree
   changes (`settings.json` model/skip/effort, `.config/zed/settings.json`,
   a LaunchAgent template) were intentionally left out; only the SessionStart
   hook hunk of `settings.json` is included.

## How to use / test

```bash
exec zsh                         # load the claude() wrapper
tmux source-file ~/.tmux.conf    # apply set-titles (or prefix + r)
cd ~/some-git-repo && claude     # window/tab -> 🤖 repo/branch

# find later:
claude --resume    # picker -> Ctrl+A (all projects), then type to search by name
claude -r <name>   # resume by name;  claude -c = most recent in this dir
```
