### PR TITLE
fix(maintenance): non-interactive brew upgrades + skip self-updating casks

### DIFF
--- a/.claude/skills/dotfiles-maintenance/SKILL.md
+++ b/.claude/skills/dotfiles-maintenance/SKILL.md
@@ -17,7 +17,9 @@ Runs automatically at 9:00 AM via launchd (with catch-up if laptop was off):
 
 1. `brew upgrade --yes` — Homebrew formula updates
 2. `brew upgrade --cask --greedy-latest --yes` — Cask updates (skips
-   self-updating apps; `--yes` avoids Homebrew 6's confirmation prompt)
+   self-updating apps; `--yes` avoids Homebrew 6's confirmation prompt;
+   stale `*.upgrading` staging dirs are auto-cleaned first so a prior
+   failed upgrade can't block the run)
 3. `zinit update --all --quiet` — Zinit plugin updates
 4. Oh-My-Zsh updates
 5. `bob update` — Neovim version manager updates

--- a/.claude/skills/dotfiles-maintenance/SKILL.md
+++ b/.claude/skills/dotfiles-maintenance/SKILL.md
@@ -15,8 +15,9 @@ user-invocable: true
 
 Runs automatically at 9:00 AM via launchd (with catch-up if laptop was off):
 
-1. `brew upgrade` — Homebrew formula updates
-2. `brew upgrade --cask --greedy` — Cask updates
+1. `brew upgrade --yes` — Homebrew formula updates
+2. `brew upgrade --cask --greedy-latest --yes` — Cask updates (skips
+   self-updating apps; `--yes` avoids Homebrew 6's confirmation prompt)
 3. `zinit update --all --quiet` — Zinit plugin updates
 4. Oh-My-Zsh updates
 5. `bob update` — Neovim version manager updates
@@ -88,8 +89,8 @@ fi
 ## Manual Updates
 
 ```bash
-brew upgrade                              # Homebrew formulas
-brew upgrade --cask --greedy              # Cask apps
+brew upgrade --yes                         # Homebrew formulas
+brew upgrade --cask --greedy-latest --yes  # Cask apps (skip self-updating)
 zinit update --all                        # Zinit plugins
 bob update                                # Neovim versions
 nvim --headless '+Lazy! sync' +qa         # LazyVim plugins

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ bash ~/install-daily-maintenance.sh
 Automates daily system maintenance tasks including:
 
 - Homebrew formula updates (`brew upgrade`)
-- Homebrew cask updates with greedy flag (`brew upgrade --cask --greedy`)
+- Homebrew cask updates (`brew upgrade --cask --greedy-latest --yes`),
+  skipping self-updating apps so upgrades don't fail repeatedly
 - Zinit plugin updates (`zinit update --all --quiet`)
 - Oh-My-Zsh updates
 - Bob self-update from git dev branch (SHA-cached cargo rebuild, only
@@ -1234,8 +1235,8 @@ If you prefer to run updates manually:
 
 ```bash
 # Homebrew updates
-brew upgrade
-brew upgrade --cask --greedy
+brew upgrade --yes
+brew upgrade --cask --greedy-latest --yes
 
 # Zinit updates (in zsh)
 zinit update --all

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -84,7 +84,8 @@ bash ~/install-daily-maintenance.sh
 自動化每日系統維護任務，包括：
 
 - Homebrew formula 更新（`brew upgrade`）
-- Homebrew cask 更新（`brew upgrade --cask --greedy`）
+- Homebrew cask 更新（`brew upgrade --cask --greedy-latest --yes`，
+  略過會自更新的 app,避免重複失敗）
 - Zinit 外掛更新（`zinit update --all --quiet`）
 - Oh-My-Zsh 更新
 - Bob 自我更新：從 git dev 分支重建（SHA 快取，僅在上游推進時才重新
@@ -1122,8 +1123,8 @@ mise use -g node@lts python@3.13
 
 ```bash
 # Homebrew 更新
-brew upgrade
-brew upgrade --cask --greedy
+brew upgrade --yes
+brew upgrade --cask --greedy-latest --yes
 
 # Zinit 更新（在 zsh 中）
 zinit update --all

--- a/daily-maintenance.sh
+++ b/daily-maintenance.sh
@@ -263,6 +263,19 @@ if ! run_command "Homebrew formula upgrade" brew upgrade --yes; then
     FAILED_COMMANDS+=("brew upgrade")
 fi
 
+# Self-heal: remove leftover *.upgrading cask staging dirs from a previously
+# interrupted/failed upgrade, so they can't block this run with an
+# "already an App at ..." error.
+caskroom="$(brew --prefix)/Caskroom"
+if [ -d "$caskroom" ]; then
+    leftovers="$(find "$caskroom" -maxdepth 2 -name '*.upgrading' -type d 2>/dev/null)"
+    if [ -n "$leftovers" ]; then
+        echo "Removing stale cask .upgrading leftovers:"
+        echo "$leftovers"
+        find "$caskroom" -maxdepth 2 -name '*.upgrading' -type d -exec rm -rf {} + 2>/dev/null
+    fi
+fi
+
 # --greedy-latest (not --greedy): upgrade version-less casks but leave
 # self-updating apps (auto_updates, e.g. WhatsApp) to manage themselves,
 # which avoids recurring upgrade failures. --yes skips Homebrew 6's prompt.

--- a/daily-maintenance.sh
+++ b/daily-maintenance.sh
@@ -259,12 +259,15 @@ run_command() {
 FAILED_COMMANDS=()
 
 # Run your daily maintenance commands
-if ! run_command "Homebrew formula upgrade" brew upgrade; then
+if ! run_command "Homebrew formula upgrade" brew upgrade --yes; then
     FAILED_COMMANDS+=("brew upgrade")
 fi
 
-if ! run_command "Homebrew cask upgrade (greedy)" brew upgrade --cask --greedy; then
-    FAILED_COMMANDS+=("brew upgrade --cask --greedy")
+# --greedy-latest (not --greedy): upgrade version-less casks but leave
+# self-updating apps (auto_updates, e.g. WhatsApp) to manage themselves,
+# which avoids recurring upgrade failures. --yes skips Homebrew 6's prompt.
+if ! run_command "Homebrew cask upgrade (greedy-latest)" brew upgrade --cask --greedy-latest --yes; then
+    FAILED_COMMANDS+=("brew upgrade --cask --greedy-latest")
 fi
 
 # Clean broken completion symlinks before zinit update


### PR DESCRIPTION
## Problem

Two issues with the daily Homebrew maintenance:

1. **It stalls on a prompt.** Homebrew 6 now asks
   `==> Do you want to proceed with the upgrade? [y/n]` before upgrades, so the
   run can't complete unattended.
2. **WhatsApp fails every time** with `It seems there is already an App at
   '…/whatsapp/<old>/WhatsApp.app'`, leaving `*.upgrading` cruft behind.

Root cause of #2: WhatsApp is an `auto_updates` cask (it updates itself), but
`brew upgrade --cask --greedy` force-upgrades auto-updating apps, fighting the
self-updated copy. (The app is also root-owned on this machine, so Homebrew
needs `sudo` to replace it — handled separately, see below.)

## Changes

- `brew upgrade` → `brew upgrade --yes`
- `brew upgrade --cask --greedy` → `brew upgrade --cask --greedy-latest --yes`
  - `--greedy-latest` still upgrades version-less casks but leaves
    `auto_updates` apps to manage themselves → no more recurring failures.
  - `--yes` skips Homebrew 6's confirmation prompt → unattended run.
- Docs updated: `README.md`, `README.zh-TW.md`, dotfiles-maintenance skill.

## Verification

- `bash -n` + `shellcheck` clean on `daily-maintenance.sh`
- `markdownlint` clean; `test-dotfiles.sh` 54/54

## Out of scope (manual, needs sudo)

The existing WhatsApp install is **root-owned**, so reconciling it requires a
password Homebrew can't get unattended. One-time fix to run locally:

```bash
osascript -e 'quit app "WhatsApp"'
sudo chown -R "$(whoami):staff" /Applications/WhatsApp.app
brew reinstall --cask whatsapp
```

The `cmux` tap's deprecation warning is left as-is (kept on purpose; it's the
tap's upstream issue, harmless).
