### PR TITLE
docs(maintenance): correct cask-upgrade note + add root-owned-app hint

### DIFF
--- a/.claude/skills/dotfiles-maintenance/SKILL.md
+++ b/.claude/skills/dotfiles-maintenance/SKILL.md
@@ -16,10 +16,10 @@ user-invocable: true
 Runs automatically at 9:00 AM via launchd (with catch-up if laptop was off):
 
 1. `brew upgrade --yes` — Homebrew formula updates
-2. `brew upgrade --cask --greedy-latest --yes` — Cask updates (skips
-   self-updating apps; `--yes` avoids Homebrew 6's confirmation prompt;
-   stale `*.upgrading` staging dirs are auto-cleaned first so a prior
-   failed upgrade can't block the run)
+2. `brew upgrade --cask --greedy-latest --yes` — Cask updates (`--yes`
+   avoids Homebrew 6's confirmation prompt; also covers version-less casks;
+   stale `*.upgrading` staging dirs are auto-cleaned first so a prior failed
+   upgrade can't block the run)
 3. `zinit update --all --quiet` — Zinit plugin updates
 4. Oh-My-Zsh updates
 5. `bob update` — Neovim version manager updates
@@ -92,7 +92,7 @@ fi
 
 ```bash
 brew upgrade --yes                         # Homebrew formulas
-brew upgrade --cask --greedy-latest --yes  # Cask apps (skip self-updating)
+brew upgrade --cask --greedy-latest --yes  # Cask apps
 zinit update --all                        # Zinit plugins
 bob update                                # Neovim versions
 nvim --headless '+Lazy! sync' +qa         # LazyVim plugins

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ bash ~/install-daily-maintenance.sh
 Automates daily system maintenance tasks including:
 
 - Homebrew formula updates (`brew upgrade`)
-- Homebrew cask updates (`brew upgrade --cask --greedy-latest --yes`),
-  skipping self-updating apps so upgrades don't fail repeatedly
+- Homebrew cask updates (`brew upgrade --cask --greedy-latest --yes`):
+  non-interactive, and also covers version-less casks
 - Zinit plugin updates (`zinit update --all --quiet`)
 - Oh-My-Zsh updates
 - Bob self-update from git dev branch (SHA-cached cargo rebuild, only

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -84,8 +84,8 @@ bash ~/install-daily-maintenance.sh
 自動化每日系統維護任務，包括：
 
 - Homebrew formula 更新（`brew upgrade`）
-- Homebrew cask 更新（`brew upgrade --cask --greedy-latest --yes`，
-  略過會自更新的 app,避免重複失敗）
+- Homebrew cask 更新 — `brew upgrade --cask --greedy-latest --yes`:
+  非互動式,並涵蓋無版本號的 cask
 - Zinit 外掛更新（`zinit update --all --quiet`）
 - Oh-My-Zsh 更新
 - Bob 自我更新：從 git dev 分支重建（SHA 快取，僅在上游推進時才重新

--- a/daily-maintenance.sh
+++ b/daily-maintenance.sh
@@ -276,11 +276,18 @@ if [ -d "$caskroom" ]; then
     fi
 fi
 
-# --greedy-latest (not --greedy): upgrade version-less casks but leave
-# self-updating apps (auto_updates, e.g. WhatsApp) to manage themselves,
-# which avoids recurring upgrade failures. --yes skips Homebrew 6's prompt.
+# Upgrade casks. --greedy-latest also covers version-less (:latest) casks that
+# plain "brew upgrade" skips; --yes skips Homebrew 6's confirmation prompt so
+# the run stays unattended. (An auto_updates app is still upgraded by brew when
+# a newer cask version exists -- that's expected, not a problem.)
 if ! run_command "Homebrew cask upgrade (greedy-latest)" brew upgrade --cask --greedy-latest --yes; then
     FAILED_COMMANDS+=("brew upgrade --cask --greedy-latest")
+    # Most common cause of a cask failure: its app in /Applications is owned by
+    # root (usually from a past "sudo brew"), so Homebrew needs sudo to replace
+    # it. Surface the one-line fix instead of a cryptic "already an App" error.
+    echo "Hint: a failed cask is often a root-owned /Applications app."
+    echo "      Check: ls -ld \"/Applications/<App>.app\""
+    echo "      Fix:   sudo chown -R \"$(whoami):staff\" \"/Applications/<App>.app\"  (never run 'sudo brew')"
 fi
 
 # Clean broken completion symlinks before zinit update

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -180,6 +180,13 @@ run_test "Daily maintenance script structure" "bash /tmp/test_maintenance.sh"
 if [ -f "$HOME/daily-maintenance.sh" ]; then
     run_test "Daily maintenance includes mise upgrade" \
         "grep -qE '^[[:space:]]*(run_command|mise upgrade|\"Mise runtime upgrade\")' $HOME/daily-maintenance.sh && grep -q 'mise upgrade' $HOME/daily-maintenance.sh"
+    # brew upgrades must stay non-interactive (Homebrew 6 prompts otherwise),
+    # or the unattended run stalls. Guard: every run_command brew upgrade has --yes.
+    run_test "Maintenance brew upgrades are non-interactive (--yes)" \
+        "! grep -E 'run_command .*brew upgrade' $HOME/daily-maintenance.sh | grep -qv -- '--yes'"
+    # Guard the self-heal that clears stale cask *.upgrading staging dirs.
+    run_test "Maintenance self-heals stale cask .upgrading dirs" \
+        "grep -qF '.upgrading' $HOME/daily-maintenance.sh"
 fi
 echo
 


### PR DESCRIPTION
## Why

While chasing the recurring WhatsApp/cask upgrade failures, two things became clear:

1. The `--greedy-latest` note I added in #52 was **wrong** — it does *not*
   "skip self-updating apps." `brew upgrade --cask` upgrades an `auto_updates`
   app whenever a newer cask version exists (verified via `--dry-run`).
2. The real cause of the `It seems there is already an App at …` failures was
   `/Applications/<App>.app` being owned by **root** (from a past `sudo brew`),
   so Homebrew needs `sudo` to replace it — which prompts interactively and
   fails unattended.

## What this PR does

- Corrects the misleading comment in `daily-maintenance.sh` and the matching
  wording in `README.md`, `README.zh-TW.md`, and the dotfiles-maintenance skill.
- Adds a **failure hint** to the cask-upgrade step: if it fails, print the exact
  `sudo chown -R "$(whoami):staff" "/Applications/<App>.app"` fix (and "never run
  `sudo brew`") instead of a cryptic error.

## What this PR deliberately does NOT do

An automatic "skip root-owned casks" guard was evaluated and **rejected**:
Homebrew's cask→app mapping is unreliable (e.g. `adguard`/`sf-symbols` extract to
nothing, `readwise-ibooks` → `Readwise_iBooks.app` but the real app is
`Readwise.app`), so such a guard would miss the very apps it should catch —
worse than none. The unattended 9am run is already resilient (no tty → sudo
fails fast → it continues); the real prevention is "don't `sudo brew`."

## Verification

`bash -n` + `shellcheck` clean; `markdownlint` clean; `test-dotfiles.sh` 54/54.
