### PR TITLE
feat: herdr 2-week trial for Claude Code sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,46 +1,16 @@
 {
-  "model": "claude-fable-5[1m]",
-  "hooks": {
-    "Notification": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.local/bin/claude-notify"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.local/bin/claude-name-session"
-          }
-        ]
-      }
-    ]
-  },
-  "statusLine": {
-    "type": "command",
-    "command": "~/.local/bin/claude-statusline",
-    "refreshInterval": 5
-  },
   "enabledPlugins": {
-    "lua-lsp@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true,
-    "context7@claude-plugins-official": true,
-    "code-review@claude-plugins-official": true,
-    "github@claude-plugins-official": true,
-    "superpowers@claude-plugins-official": true,
     "apify-actor-development@apify-agent-skills": true,
     "apify-ultimate-scraper@apify-agent-skills": true,
+    "code-review@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
     "ghostty-config@ghostty-config-dev": true,
+    "github@claude-plugins-official": true,
+    "lua-lsp@claude-plugins-official": true,
+    "obsidian@obsidian-skills": true,
     "pyright-lsp@claude-plugins-official": true,
-    "obsidian@obsidian-skills": true
+    "superpowers@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "apify-agent-skills": {
@@ -51,17 +21,57 @@
     },
     "ghostty-config-dev": {
       "source": {
-        "source": "github",
-        "repo": "shyuan/ghostty-config-plugin"
+        "repo": "shyuan/ghostty-config-plugin",
+        "source": "github"
       }
     },
     "obsidian-skills": {
       "source": {
-        "source": "github",
-        "repo": "kepano/obsidian-skills"
+        "repo": "kepano/obsidian-skills",
+        "source": "github"
       }
     }
   },
-  "tui": "fullscreen",
-  "theme": "custom:my-theme"
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "command": "~/.local/bin/claude-notify",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "~/.local/bin/claude-name-session",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      },
+      {
+        "hooks": [
+          {
+            "command": "bash \"$HOME/.claude/hooks/herdr-agent-state.sh\" session",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
+      }
+    ]
+  },
+  "model": "claude-fable-5[1m]",
+  "statusLine": {
+    "command": "~/.local/bin/claude-statusline",
+    "refreshInterval": 5,
+    "type": "command"
+  },
+  "theme": "custom:my-theme",
+  "tui": "fullscreen"
 }

--- a/.claude/skills/dotfiles-commit/SKILL.md
+++ b/.claude/skills/dotfiles-commit/SKILL.md
@@ -50,6 +50,9 @@ yadm push             # Push to GitHub
 
 ## Signing & Push Transport
 
+Scope: personal machines. Work machines follow their own untracked
+`~/.gitconfig` (see `docs/work-machine-checklist.md`).
+
 - Commits are SSH-signed via the 1Password agent (`op-ssh-sign`,
   machine-local `~/.gitconfig`). If a commit fails with a signing
   error, 1Password is probably locked — unlock it and retry; never

--- a/.claude/skills/dotfiles-commit/SKILL.md
+++ b/.claude/skills/dotfiles-commit/SKILL.md
@@ -48,6 +48,16 @@ yadm commit -m "msg"  # Commit
 yadm push             # Push to GitHub
 ```
 
+## Signing & Push Transport
+
+- Commits are SSH-signed via the 1Password agent (`op-ssh-sign`,
+  machine-local `~/.gitconfig`). If a commit fails with a signing
+  error, 1Password is probably locked — unlock it and retry; never
+  work around it with `--no-gpg-sign`.
+- The yadm remote is `git@github.com:` (SSH through the 1Password
+  agent). HTTPS pushes fail on this machine — never "fix" a push
+  failure by switching the remote back to HTTPS.
+
 ## Author Configuration
 
 Verify before first commit in a session:

--- a/.claude/skills/dotfiles-shell/SKILL.md
+++ b/.claude/skills/dotfiles-shell/SKILL.md
@@ -4,8 +4,8 @@ description: |
   Use when user mentions "zshrc", "shell config", "zinit", "oh-my-zsh",
   "tmux", "alias", "fzf", "zoxide", "sesh", "ghostty", "kitty",
   "terminal", "atuin", "starship", "carapace", "yazi", "mise",
-  "television", "glow", "serpl", "jj", "jujutsu", or discusses
-  shell, terminal, or multiplexer configuration.
+  "television", "glow", "scooter", "herdr", "jj", "jujutsu", or
+  discusses shell, terminal, or multiplexer configuration.
 version: 1.0.0
 tools: Read, Glob, Grep, Bash, Edit
 user-invocable: true
@@ -59,7 +59,7 @@ user-invocable: true
 - `ms` — Maintenance status
 - `ml` — Maintenance logs
 - `cat` → `bat`, `vim` → `nvim`, `cd` → `z`
-- `y` → yazi (file manager, cd on exit), `sr` → serpl, `md` → glow
+- `y` → yazi (file manager, cd on exit), `sr` → scooter, `md` → glow
 - Modern CLI replacements: `ls`→eza, `du`→dust, `df`→duf, `top`→btop,
   `grep`→rg, `find`→fd, `dig`→doggo, `ps`→procs
 
@@ -95,8 +95,9 @@ user-invocable: true
 - **tmux-continuum** — Auto-save sessions
 - **Catppuccin theme** — Mocha variant
 - **tmux-claude-session-manager** — `prefix+y` launch/attach Claude for the
-  cwd; `prefix+u` fzf picker of live Claude sessions (working/waiting/idle
-  status via `scripts/state.sh` hooks + live preview)
+  cwd; `prefix+u` fzf picker of live Claude sessions (v1.1.0+: status read
+  live from `claude agents` — the old `state.sh` settings.json hooks were
+  removed and must never be re-added)
 
 ### Session Management (sesh)
 

--- a/.claude/skills/dotfiles-shell/SKILL.md
+++ b/.claude/skills/dotfiles-shell/SKILL.md
@@ -134,7 +134,9 @@ Tab/Shift-Tab to navigate, Ctrl-x for zoxide dirs, Ctrl-d to kill session.
 
 - Pager: **delta** with syntax highlighting
 - Merge conflict style: **zdiff3**
-- Credential helper: Git Credential Manager
+- GitHub auth: **SSH via the 1Password agent** (`git@github.com:` remotes;
+  see `~/.ssh/config.d/10-github-1password.conf`). Git Credential Manager
+  was removed 2026-08 and HTTPS remotes now fail.
 - User: Nick Liu (`nickboy@users.noreply.github.com`)
 
 ## Terminal Emulators

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -89,6 +89,35 @@ type = "plugin_action"
 command = "sessionizer.worktree-open"
 description = "open worktree workspace"
 
+# termscope: pick files/links visible on screen (tmux-thumbs successor).
+# Prefix-based on purpose — bare ctrl+e/a would steal readline keys.
+[[keys.command]]
+key = "prefix+u"
+type = "plugin_action"
+command = "termscope.open-links"
+description = "open visible link picker"
+
+[[keys.command]]
+key = "prefix+shift+u"
+type = "plugin_action"
+command = "termscope.open"
+description = "open visible file picker"
+
+# jj workspaces. The plugin's 'remove' action is deliberately UNBOUND:
+# it is destructive (jj workspace forget + rm -rf of the directory,
+# untracked files included) — invoke it from the action menu when meant.
+[[keys.command]]
+key = "prefix+shift+j"
+type = "plugin_action"
+command = "nathanflurry.jj-workspace.new"
+description = "new jj workspace"
+
+[[keys.command]]
+key = "prefix+alt+j"
+type = "plugin_action"
+command = "nathanflurry.jj-workspace.new-tab"
+description = "new jj workspace (tab)"
+
 # ── Notifications: split duties with the claude-notify hook ────────
 # In-app toasts only; desktop banners stay with claude-notify (OSC 777)
 # to avoid double notifications.

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,117 @@
+# herdr config — 2-week trial (Claude Code sessions only; tmux stays primary)
+# Migrated from .tmux.conf muscle memory; keys validated against
+# `herdr --default-config` (0.7.5). Reload: herdr server reload-config
+
+onboarding = false
+
+# ── Theme: mirrors catppuccin/tmux (mocha) ─────────────────────────
+[theme]
+name = "catppuccin"
+auto_switch = false
+
+[theme.custom]
+panel_bg = "reset" # like tmux window-style bg=default: Ghostty transparency shows through
+
+# ── Terminal behavior ──────────────────────────────────────────────
+[terminal]
+new_cwd = "follow" # like split-window -c "#{pane_current_path}"
+
+# ── Keys: keep tmux muscle memory ──────────────────────────────────
+# Defaults that already match the tmux config (left unset on purpose):
+#   focus_pane_left/down/up/right = prefix+h/j/k/l
+#   split_horizontal = prefix+minus, resize_mode = prefix+r,
+#   help = prefix+?, switch_tab = prefix+1..9, reload_config = prefix+shift+r
+[keys]
+prefix = "ctrl+a"
+# "backslash" is valid per keybinds source even though the docs' named-
+# punctuation list omits it (verified upstream) — mirrors tmux `bind \\`
+split_vertical = "prefix+backslash"
+
+# workspace entry points (sesh replacement lives here during the trial)
+goto = "prefix+g"
+workspace_picker = "prefix+w"
+new_workspace = "prefix+shift+n"
+new_worktree = "prefix+shift+g" # one isolated worktree per agent
+
+# lazygit popup — replaces the fzf-tmux popup habit
+[[keys.command]]
+key = "prefix+alt+g"
+type = "popup"
+command = "lazygit"
+width = "85%"
+height = "85%"
+
+# scratch terminal popup
+[[keys.command]]
+key = "prefix+t"
+type = "popup"
+command = "zsh"
+width = "80%"
+height = "70%"
+
+# ── Plugin bindings ────────────────────────────────────────────────
+# vim-herdr-navigation: same bare ctrl+hjkl contract as the existing
+# tmux vim-tmux-navigator plugin — vim-aware, falls through to pane focus
+[[keys.command]]
+key = "ctrl+h"
+type = "plugin_action"
+command = "vim-herdr-navigation.left"
+description = "navigate left (vim/herdr)"
+
+[[keys.command]]
+key = "ctrl+j"
+type = "plugin_action"
+command = "vim-herdr-navigation.down"
+description = "navigate down (vim/herdr)"
+
+[[keys.command]]
+key = "ctrl+k"
+type = "plugin_action"
+command = "vim-herdr-navigation.up"
+description = "navigate up (vim/herdr)"
+
+[[keys.command]]
+key = "ctrl+l"
+type = "plugin_action"
+command = "vim-herdr-navigation.right"
+description = "navigate right (vim/herdr)"
+
+# sessionizer: project picker / worktree picker (sesh 'T' successor)
+[[keys.command]]
+key = "prefix+f"
+type = "plugin_action"
+command = "sessionizer.open"
+description = "open project workspace"
+
+[[keys.command]]
+key = "prefix+shift+f"
+type = "plugin_action"
+command = "sessionizer.worktree-open"
+description = "open worktree workspace"
+
+# ── Notifications: split duties with the claude-notify hook ────────
+# In-app toasts only; desktop banners stay with claude-notify (OSC 777)
+# to avoid double notifications.
+[ui.toast]
+delivery = "herdr"
+delay_seconds = 1
+
+[ui.toast.herdr]
+position = "bottom-right"
+
+# ── Session persistence (replaces resurrect/continuum inside herdr) ─
+[session]
+resume_agents_on_restore = true
+
+[worktrees]
+directory = "~/.herdr/worktrees"
+
+# ── Experimental ───────────────────────────────────────────────────
+[experimental]
+# yazi/image previews; turn off if unstable
+kitty_graphics = true
+# macOS CJK IME candidate window follows the Claude Code cursor
+reveal_hidden_cursor_for_cjk_ime = true
+cjk_ime_agents = ["claude"]
+# Keep OFF: would persist pane output (possibly secrets) to disk
+pane_history = false

--- a/.config/herdr/config.toml##template
+++ b/.config/herdr/config.toml##template
@@ -122,12 +122,17 @@ command = "nathanflurry.jj-workspace.new-tab"
 description = "new jj workspace (tab)"
 
 # ── Notifications ──────────────────────────────────────────────────
-# "system" = OS notification center, delivered by the CLIENT side:
-# local agents notify here, and with --remote the client is still this
-# Mac — remote agents' notifications land locally too. claude-notify
-# stands down inside herdr panes (herdr eats OSC 9/777), so no doubles.
+# "terminal" = the CLIENT asks its outer terminal (Ghostty) to post
+# the banner. Chosen over "system" on purpose: macOS only has GHOSTTY
+# registered in Notification Center (com.apple.ncprefs) — herdr's
+# system path (terminal-notifier/osascript) gets silently dropped.
+# Works for every topology: local, --remote (client is local Ghostty),
+# and ssh+herdr (OSC rides the SSH channel back to Ghostty).
+# Banner shows only while Ghostty is unfocused — Ghostty's policy,
+# same behavior as the old claude-notify chain. claude-notify itself
+# stands down inside herdr panes (herdr eats pane OSC 9/777).
 [ui.toast]
-delivery = "system"
+delivery = "terminal"
 delay_seconds = 1
 
 [ui.toast.herdr]

--- a/.config/herdr/config.toml##template
+++ b/.config/herdr/config.toml##template
@@ -1,6 +1,9 @@
-# herdr config — 2-week trial (Claude Code sessions only; tmux stays primary)
+# herdr config — yadm template: `yadm alt` generates config.toml from
+# this file (edit the template, never the generated file). One config
+# for every machine; only the experimental block branches per OS.
 # Migrated from .tmux.conf muscle memory; keys validated against
 # `herdr --default-config` (0.7.5). Reload: herdr server reload-config
+# Full setup guide (Mac + remote Linux): ~/docs/herdr-setup.md
 
 onboarding = false
 
@@ -118,11 +121,13 @@ type = "plugin_action"
 command = "nathanflurry.jj-workspace.new-tab"
 description = "new jj workspace (tab)"
 
-# ── Notifications: split duties with the claude-notify hook ────────
-# In-app toasts only; desktop banners stay with claude-notify (OSC 777)
-# to avoid double notifications.
+# ── Notifications ──────────────────────────────────────────────────
+# "system" = OS notification center, delivered by the CLIENT side:
+# local agents notify here, and with --remote the client is still this
+# Mac — remote agents' notifications land locally too. claude-notify
+# stands down inside herdr panes (herdr eats OSC 9/777), so no doubles.
 [ui.toast]
-delivery = "herdr"
+delivery = "system"
 delay_seconds = 1
 
 [ui.toast.herdr]
@@ -137,10 +142,15 @@ directory = "~/.herdr/worktrees"
 
 # ── Experimental ───────────────────────────────────────────────────
 [experimental]
+{% if yadm.os == "Darwin" %}
 # yazi/image previews; turn off if unstable
 kitty_graphics = true
 # macOS CJK IME candidate window follows the Claude Code cursor
 reveal_hidden_cursor_for_cjk_ime = true
 cjk_ime_agents = ["claude"]
+{% else %}
+# Linux/remote servers: experimental graphics on top of SSH — keep off
+kitty_graphics = false
+{% endif %}
 # Keep OFF: would persist pane output (possibly secrets) to disk
 pane_history = false

--- a/.config/herdr/plugins/config/sessionizer/config.toml
+++ b/.config/herdr/plugins/config/sessionizer/config.toml
@@ -1,0 +1,36 @@
+# Sessionizer (herdr plugin) — sesh successor for the herdr trial.
+# Pickers fuzzy over these roots; the [tabs] layout below is applied
+# only when a NEW workspace is created (existing ones are just focused).
+
+[projects]
+# ~ covers the repos that live flat in $HOME (dotfiles, plum, ...);
+# git_only keeps the listing to real repos.
+roots = ["~/src", "~/Workspace", "~"]
+git_only = true
+depth = 1
+
+[ui]
+placement = "popup"
+width = "90%"
+height = "90%"
+
+[layout]
+focus = "agent"
+
+# One tab: editor left, Claude Code right (the point of the trial).
+[tabs.main]
+label = "main"
+
+[[tabs.main.panes]]
+id = "editor"
+title = "nvim"
+command = "nvim ."
+
+[[tabs.main.panes]]
+id = "agent"
+from = "editor"
+split = "right"
+ratio = 0.45
+title = "claude"
+command = "claude"
+accept_command_override = true

--- a/.config/nvim/after/plugin/herdr_nav.lua
+++ b/.config/nvim/after/plugin/herdr_nav.lua
@@ -1,0 +1,13 @@
+-- Editor side of vim-herdr-navigation (herdr plugin, SHA-pinned install).
+-- Sourced from the installed plugin so it never drifts from the herdr side;
+-- silently no-ops on machines without herdr. Outside herdr it falls back to
+-- tmux ($TMUX) or plain wincmd, so it is safe to load unconditionally and
+-- it replaces LazyVim's default <C-h/j/k/l> window maps with aware ones.
+local matches = vim.fn.glob(
+  vim.fn.expand("~/.config/herdr/plugins/github/vim-herdr-navigation-*/editor/nvim.lua"),
+  false,
+  true
+)
+if #matches > 0 then
+  dofile(matches[1])
+end

--- a/.local/bin/claude-name-session
+++ b/.local/bin/claude-name-session
@@ -42,9 +42,26 @@ emit() {  # $1 = title
     fi
 }
 
+# Inside a herdr pane, mirror the title onto the herdr TAB — the
+# equivalent of the tmux window rename that set-titles forwards.
+# Best-effort and stdout-silent: hook output must stay pure JSON.
+herdr_tab_name() {  # $1 = title
+    [ -n "${HERDR_TAB_ID:-}" ] || return 0
+    have herdr || return 0
+    herdr tab rename "$HERDR_TAB_ID" "$1" >/dev/null 2>&1 || true
+}
+
 case "$(jget source)" in
     startup) ;;
-    resume) [ -n "$(jget session_title)" ] && exit 0 ;;
+    resume)
+        t="$(jget session_title)"
+        if [ -n "$t" ]; then
+            # Title exists (set by /rename or a past run): never overwrite
+            # the session title, but do mirror it onto a fresh herdr tab.
+            herdr_tab_name "$t"
+            exit 0
+        fi
+        ;;
     *) exit 0 ;;
 esac
 
@@ -75,4 +92,5 @@ if [ -n "${SSH_CONNECTION:-}" ]; then
     label="${host%%.*}:$label"
 fi
 
+herdr_tab_name "$label"
 emit "$label"

--- a/.local/bin/claude-notify
+++ b/.local/bin/claude-notify
@@ -10,6 +10,15 @@ set -euo pipefail
 #    Ghostty shows banner only when window/surface unfocused)
 # 3. terminal-notifier/notify-send → fallback for non-Ghostty
 
+# 0. herdr pane: herdr consumes OSC 9/777 instead of forwarding them
+#    (the OSC 9 payload even pollutes the agent-progress display), so
+#    banners can never escape the pane. Notifications there come from
+#    herdr's agent engine + system toasts (ui.toast delivery="system").
+#    Stand down. (if-form on purpose: `[ ] && exit` trips set -e.)
+if [ -n "${HERDR_PANE_ID:-}" ]; then
+  exit 0
+fi
+
 target_tty="/dev/tty"
 my_tty=$(command -p ps -o tty= -p $$ 2>/dev/null | tr -d ' ')
 pid=$$

--- a/.ssh/config.d/10-github-1password.conf
+++ b/.ssh/config.d/10-github-1password.conf
@@ -1,0 +1,16 @@
+# GitHub auth via the 1Password SSH agent (managed via YADM)
+#
+# The GitHub key lives in 1Password, not on disk, so ssh has to be pointed at the
+# 1Password agent socket rather than the default launchd agent.
+#
+# Scoped to github.com on purpose: 00-defaults.conf sets `Host *` options that corporate
+# and other hosts rely on, and forcing every host through the 1Password agent would
+# break them.
+#
+# IdentitiesOnly is relaxed here because 00-defaults.conf sets `IdentitiesOnly yes`
+# globally. That option makes ssh ignore agent-provided keys unless a matching
+# IdentityFile is configured, and there is no file to point at when the key only exists
+# inside 1Password.
+Host github.com
+    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+    IdentitiesOnly no

--- a/.yadmignore
+++ b/.yadmignore
@@ -28,7 +28,9 @@ Library/LaunchAgents/com.daily-maintenance.plist
 __pycache__/
 node_modules/
 
-# herdr runtime artifacts (config.toml and plugins/config/ ARE tracked)
+# herdr: config.toml is GENERATED from config.toml##template by yadm alt
+.config/herdr/config.toml
+# herdr runtime artifacts (the ##template and plugins/config/ ARE tracked)
 .config/herdr/plugins/github/
 .config/herdr/plugins.json
 .config/herdr/.plugins.lock

--- a/.yadmignore
+++ b/.yadmignore
@@ -27,3 +27,9 @@ Library/LaunchAgents/com.daily-maintenance.plist
 *.pyc
 __pycache__/
 node_modules/
+
+# herdr runtime artifacts (config.toml and plugins/config/ ARE tracked)
+.config/herdr/plugins/github/
+.config/herdr/plugins.json
+.config/herdr/.plugins.lock
+.config/herdr/*.sock

--- a/.zshrc
+++ b/.zshrc
@@ -345,7 +345,14 @@ alias hh='atuin history list --cmd-only | bat -l bash --style=plain'
 
 # Shortcuts
 alias c='clear'
-# Use zoxide for cd (skip in Claude Code to avoid interference)
+# Use zoxide for cd (skip in Claude Code to avoid interference).
+# herdr carve-out: if the herdr server was ever started from a Claude
+# Code shell, every pane inherits CLAUDECODE=1 — but a real Claude Code
+# subshell never sources .zshrc interactively, so inside a herdr pane
+# the flag is always stale noise. Clear it so user panes get zoxide.
+if [[ -n "$HERDR_PANE_ID" && -n "$CLAUDECODE" ]]; then
+    unset CLAUDECODE
+fi
 if [[ -z "$CLAUDECODE" ]]; then
     alias cd='z'
 fi

--- a/.zshrc
+++ b/.zshrc
@@ -507,6 +507,12 @@ if command -v scooter &> /dev/null; then
     alias sr='scooter'
 fi
 
+# herdr trial: let TUIs that use C-hjkl themselves (lazygit) receive the
+# chord instead of vim-herdr-navigation moving pane focus
+if command -v herdr &> /dev/null; then
+    export HERDR_NAV_PASSTHROUGH_RE='^lazygit$'
+fi
+
 # File management (yazi with cd-on-exit wrapper)
 if command -v yazi &> /dev/null; then
     function y() {

--- a/Brewfile
+++ b/Brewfile
@@ -156,6 +156,10 @@ brew "yadm"
 brew "yazi"
 # Terminal multiplexer (modern tmux alternative)
 brew "zellij"
+# AI-agent-aware multiplexer — 2-week trial for Claude Code sessions.
+# brew-pinned during the trial: protocol-version mismatch refuses attach,
+# so upgrades must be deliberate (unpin or `herdr update` when chosen).
+brew "herdr"
 # Shell extension to navigate your filesystem faster
 brew "zoxide"
 # Magical shell history with sync and search

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,11 +58,24 @@ macOS (Apple Silicon) development environment:
    Homebrew. Run `:TSUpdate` after updating nvim-treesitter.
 
 9. **No secrets in dotfiles** — Use `.gitignore` for sensitive files.
-   Git credentials use the macOS `osxkeychain` helper by default
-   (see `~/.config/git/config`). Commits are SSH-signed via the
-   1Password agent (`op-ssh-sign`, configured in the untracked
-   `~/.gitconfig`; public keys in tracked `~/.ssh/allowed_signers`).
-   Git Credential Manager was removed 2026-08.
+   GitHub auth goes over **SSH through the 1Password agent**: the key
+   lives in 1Password with no private key on disk, routed by
+   `~/.ssh/config.d/10-github-1password.conf`, so remotes must use
+   `git@github.com:` and not `https://`. The same key signs commits
+   (`op-ssh-sign`, configured in the untracked `~/.gitconfig`; public
+   keys in tracked `~/.ssh/allowed_signers`).
+
+   Two gotchas. A 1Password key must be added to GitHub as an
+   **authentication** key, not only a signing key; GitHub keeps those
+   lists separate, and a signing-only key still fails `git push`.
+   And `00-defaults.conf` sets `IdentitiesOnly yes` globally, which
+   makes ssh ignore agent keys, so any host using 1Password needs
+   `IdentitiesOnly no`.
+
+   Git Credential Manager was removed 2026-08. The stale `osxkeychain`
+   entry it left behind is why an HTTPS remote fails with
+   "Invalid username or token" — switch the remote to SSH rather than
+   trying to repair the credential.
 
 ## Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,12 +58,19 @@ macOS (Apple Silicon) development environment:
    Homebrew. Run `:TSUpdate` after updating nvim-treesitter.
 
 9. **No secrets in dotfiles** — Use `.gitignore` for sensitive files.
-   GitHub auth goes over **SSH through the 1Password agent**: the key
-   lives in 1Password with no private key on disk, routed by
-   `~/.ssh/config.d/10-github-1password.conf`, so remotes must use
-   `git@github.com:` and not `https://`. The same key signs commits
-   (`op-ssh-sign`, configured in the untracked `~/.gitconfig`; public
-   keys in tracked `~/.ssh/allowed_signers`).
+   The invariant on EVERY machine: credentials and identity live in
+   untracked files (`~/.gitconfig`, machine ssh config), never in
+   tracked ones. The specifics below describe the PERSONAL machines;
+   on work machines (enterprise hosting, no 1Password) follow that
+   machine's own `~/.gitconfig` instead — see
+   `docs/work-machine-checklist.md`.
+
+   Personal machines: GitHub auth goes over **SSH through the
+   1Password agent** — the key lives in 1Password with no private key
+   on disk, routed by `~/.ssh/config.d/10-github-1password.conf`, so
+   remotes must use `git@github.com:` and not `https://`. The same
+   key signs commits (`op-ssh-sign`, configured in the untracked
+   `~/.gitconfig`; public keys in tracked `~/.ssh/allowed_signers`).
 
    Two gotchas. A 1Password key must be added to GitHub as an
    **authentication** key, not only a signing key; GitHub keeps those

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,10 +72,10 @@ macOS (Apple Silicon) development environment:
    makes ssh ignore agent keys, so any host using 1Password needs
    `IdentitiesOnly no`.
 
-   Git Credential Manager was removed 2026-08. The stale `osxkeychain`
-   entry it left behind is why an HTTPS remote fails with
-   "Invalid username or token" — switch the remote to SSH rather than
-   trying to repair the credential.
+   Git Credential Manager was removed 2026-08. HTTPS remotes fail with
+   "Invalid username or token" (the `osxkeychain`-cached credential is
+   stale) — switch the remote to SSH rather than trying to repair the
+   credential.
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -808,6 +808,10 @@ Known limits vs the tmux stack: sessionizer has no blacklist and its
 picker preview is hard-coded (`bat`/`ls`, not eza); the jj plugin's
 *remove* action is destructive (forget + `rm -rf`, left unbound).
 
+Full dual-machine setup (work laptop / remote Linux server, remote
+attach, notifications, upgrade discipline):
+[docs/herdr-setup.md](docs/herdr-setup.md)
+
 ## 🖥️ Tmux Configuration
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ configurations for macOS development environment.
 1. **Clone the dotfiles repository:**
 
 ```bash
+# HTTPS works anonymously for the initial clone (fresh machine has no
+# SSH agent yet):
 yadm clone https://github.com/nickboy/dotfiles.git
+
+# After the 1Password SSH agent is set up, switch the remote — pushes
+# only work over SSH on this setup:
+yadm remote set-url origin git@github.com:nickboy/dotfiles.git
 ```
 
 The bootstrap script will automatically run after cloning to:

--- a/README.md
+++ b/README.md
@@ -782,16 +782,25 @@ zjd             # zellij delete-session
 two-week trial for Claude Code sessions only — tmux stays primary.
 Formula is `brew pin`ned (its wire protocol refuses attach across any
 version mismatch). Config: `~/.config/herdr/config.toml` (ctrl+a
-prefix, tmux-mirrored keys, Catppuccin). Plugins are machine-local,
-commit-pinned by herdr; on a new machine:
+prefix, tmux-mirrored keys, Catppuccin). Plugins are machine-local;
+on a new machine install them SHA-pinned (small third-party repos —
+the `--ref` pin is the supply-chain guard):
 
 ```bash
-herdr plugin install --yes paulbkim-dev/vim-herdr-navigation
-herdr plugin install --yes andrewchng/herdr-sessionizer
-herdr plugin install --yes iurysza/termscope
-herdr plugin install --yes NathanFlurry/herdr-plugin-jj-workspace
+herdr plugin install --yes paulbkim-dev/vim-herdr-navigation \
+  --ref 820d48f5d9c9a7dece6a4bebfa3982ec30bbfbb7
+herdr plugin install --yes andrewchng/herdr-sessionizer \
+  --ref 20827358a8da57b83d479cf899909bbf11919541
+herdr plugin install --yes iurysza/termscope \
+  --ref cbc6da8103c263343b7082e27e804cc91312f944   # build may brew-bump tv
+herdr plugin install --yes NathanFlurry/herdr-plugin-jj-workspace \
+  --ref a9f1d3bcdaa2354e336a5173da85cbe4970c0f2e
 herdr integration install claude   # regenerates the agent-state hook
 ```
+
+Known limits vs the tmux stack: sessionizer has no blacklist and its
+picker preview is hard-coded (`bat`/`ls`, not eza); the jj plugin's
+*remove* action is destructive (forget + `rm -rf`, left unbound).
 
 ## 🖥️ Tmux Configuration
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ yadm clone https://github.com/nickboy/dotfiles.git
 yadm remote set-url origin git@github.com:nickboy/dotfiles.git
 ```
 
+Deploying onto a machine with existing config (work laptop)? Follow
+[docs/work-machine-checklist.md](docs/work-machine-checklist.md)
+first — it covers backing up `~/.claude`, settings precedence, and
+what must stay machine-local on a public repo.
+
 The bootstrap script will automatically run after cloning to:
 
 - Set up configuration symlinks (e.g., Ghostty)

--- a/README.md
+++ b/README.md
@@ -776,6 +776,23 @@ zjd             # zellij delete-session
     └── catppuccin-mocha.kdl      # Catppuccin Mocha theme
 ```
 
+## 🤖 herdr (trial)
+
+[herdr](https://herdr.dev/) is an AI-agent-aware multiplexer under a
+two-week trial for Claude Code sessions only — tmux stays primary.
+Formula is `brew pin`ned (its wire protocol refuses attach across any
+version mismatch). Config: `~/.config/herdr/config.toml` (ctrl+a
+prefix, tmux-mirrored keys, Catppuccin). Plugins are machine-local,
+commit-pinned by herdr; on a new machine:
+
+```bash
+herdr plugin install --yes paulbkim-dev/vim-herdr-navigation
+herdr plugin install --yes andrewchng/herdr-sessionizer
+herdr plugin install --yes iurysza/termscope
+herdr plugin install --yes NathanFlurry/herdr-plugin-jj-workspace
+herdr integration install claude   # regenerates the agent-state hook
+```
+
 ## 🖥️ Tmux Configuration
 
 ### Setup

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -761,15 +761,24 @@ zjd             # zellij delete-session
 兩週試驗——只承載 Claude Code session，tmux 仍是主力。formula 已
 `brew pin`（其協定在任何版本不匹配時拒絕 attach）。設定在
 `~/.config/herdr/config.toml`（ctrl+a prefix、對映 tmux 鍵位、
-Catppuccin）。插件屬機器本地產物、由 herdr 以 commit 釘版；新機器：
+Catppuccin）。插件屬機器本地產物；新機器以 SHA 釘版安裝
+（皆為小型第三方 repo，`--ref` 是供應鏈防護）：
 
 ```bash
-herdr plugin install --yes paulbkim-dev/vim-herdr-navigation
-herdr plugin install --yes andrewchng/herdr-sessionizer
-herdr plugin install --yes iurysza/termscope
-herdr plugin install --yes NathanFlurry/herdr-plugin-jj-workspace
+herdr plugin install --yes paulbkim-dev/vim-herdr-navigation \
+  --ref 820d48f5d9c9a7dece6a4bebfa3982ec30bbfbb7
+herdr plugin install --yes andrewchng/herdr-sessionizer \
+  --ref 20827358a8da57b83d479cf899909bbf11919541
+herdr plugin install --yes iurysza/termscope \
+  --ref cbc6da8103c263343b7082e27e804cc91312f944   # build 可能經 brew 升級 television
+herdr plugin install --yes NathanFlurry/herdr-plugin-jj-workspace \
+  --ref a9f1d3bcdaa2354e336a5173da85cbe4970c0f2e
 herdr integration install claude   # 重新生成 agent-state hook
 ```
+
+相對 tmux 組合的已知限制：sessionizer 沒有 blacklist、picker 預覽
+寫死（`bat`/`ls`，非 eza）；jj 插件的 *remove* 是銷毀性操作
+（forget + `rm -rf`，故意不綁鍵）。
 
 ## Tmux 設定
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -755,6 +755,22 @@ zjd             # zellij delete-session
     └── catppuccin-mocha.kdl      # Catppuccin Mocha 主題
 ```
 
+## herdr（試驗中）
+
+[herdr](https://herdr.dev/) 是感知 AI agent 狀態的多工器，目前進行
+兩週試驗——只承載 Claude Code session，tmux 仍是主力。formula 已
+`brew pin`（其協定在任何版本不匹配時拒絕 attach）。設定在
+`~/.config/herdr/config.toml`（ctrl+a prefix、對映 tmux 鍵位、
+Catppuccin）。插件屬機器本地產物、由 herdr 以 commit 釘版；新機器：
+
+```bash
+herdr plugin install --yes paulbkim-dev/vim-herdr-navigation
+herdr plugin install --yes andrewchng/herdr-sessionizer
+herdr plugin install --yes iurysza/termscope
+herdr plugin install --yes NathanFlurry/herdr-plugin-jj-workspace
+herdr integration install claude   # 重新生成 agent-state hook
+```
+
 ## Tmux 設定
 
 ### 初始設定

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -58,6 +58,11 @@ yadm clone https://github.com/nickboy/dotfiles.git
 yadm remote set-url origin git@github.com:nickboy/dotfiles.git
 ```
 
+要部署到已有自訂設定的機器（如工作筆電）？先照
+[docs/work-machine-checklist.md](docs/work-machine-checklist.md)
+走——涵蓋 `~/.claude` 備份、設定優先序、以及公開 repo 上
+哪些東西必須留在機器本地。
+
 Bootstrap 腳本會在複製後自動執行：
 
 - 設定設定檔 symlink（例如 Ghostty）

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -51,7 +51,11 @@
 1. **複製 dotfiles 倉庫：**
 
 ```bash
+# 初次 clone 用 HTTPS（新機器還沒有 SSH agent，匿名讀取可用）：
 yadm clone https://github.com/nickboy/dotfiles.git
+
+# 1Password SSH agent 設定完成後切換 remote——此環境只有 SSH 能 push：
+yadm remote set-url origin git@github.com:nickboy/dotfiles.git
 ```
 
 Bootstrap 腳本會在複製後自動執行：

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -784,6 +784,9 @@ herdr integration install claude   # 重新生成 agent-state hook
 寫死（`bat`/`ls`，非 eza）；jj 插件的 *remove* 是銷毀性操作
 （forget + `rm -rf`，故意不綁鍵）。
 
+完整雙機建置指南（工作筆電／遠端 Linux、remote attach、通知、
+升級紀律）：[docs/herdr-setup.md](docs/herdr-setup.md)（英文）
+
 ## Tmux 設定
 
 ### 初始設定

--- a/docs/herdr-setup.md
+++ b/docs/herdr-setup.md
@@ -141,6 +141,24 @@ Toasts fire on agent transitions to done/blocked; the ACTIVE tab is
 suppressed by design — staring at a finishing agent never banners.
 Sounds for background state changes are on by default (`[ui.sound]`).
 
+Troubleshooting no-banner (learned live):
+
+1. **The client reads toast config at attach** — `server
+   reload-config` is not enough. After changing `[ui.toast]`, detach
+   and reattach every client.
+2. Client-side breadcrumb: `herdr-client.log` logs "received terminal
+   toast notification from server". Line present but no banner →
+   emission side (TERM detection / terminal permission). Line absent →
+   the server never sent it (delivery off, wrong config, or the
+   active-tab / focused suppressions).
+3. Terminal delivery silently no-ops when the client's TERM /
+   TERM_PROGRAM is not a recognized terminal — on ssh+herdr check
+   `echo $TERM` is still `xterm-ghostty` (a profile that rewrites it
+   to xterm-256color kills banners with no error).
+4. macOS: only apps registered in Notification Center can post —
+   check `defaults read com.apple.ncprefs apps`. On this Mac only
+   Ghostty is registered, which is why delivery is `terminal`.
+
 **Verified**: herdr consumes pane OSC 9/777 rather than forwarding
 them (the OSC 9 payload even pollutes the agent-progress display), so
 `claude-notify` stands down inside herdr panes (guard at the top of

--- a/docs/herdr-setup.md
+++ b/docs/herdr-setup.md
@@ -1,0 +1,209 @@
+# herdr Setup Guide (Mac + Remote Linux)
+
+Dual-machine herdr architecture for Claude Code sessions. Written for
+setting up a new work laptop (Mac) and a remote Linux work server.
+Facts marked **verified** were tested live on this setup (herdr 0.7.5);
+items marked **⚠ verify** need a one-minute check on setup day.
+
+## Architecture
+
+```text
+Mac (Ghostty)
+├─ tab 1: herdr                    → local Claude agents (local server)
+├─ tab 2: herdr --remote <host>    → remote Claude agents (Linux server)
+└─ tab 3: tmux                     → general dev (unchanged, escape pod)
+
+Fallback from any device: ssh <host> → herdr   (client/server are the
+same binary on that machine — can never version-skew)
+```
+
+Rules learned the hard way:
+
+- **Never start the herdr server from a Claude Code session.**
+  Panes inherit the server's environment; a Claude-started server
+  leaks `CLAUDECODE=1` into every pane and kills zoxide/`cd` (the
+  .zshrc guard fires for user shells). `.zshrc` now clears a stale
+  flag inside herdr panes, but the server should still be started by
+  a human running plain `herdr`. (**verified** — it happened.)
+- **No nesting**: herdr inside a herdr pane is blocked by design
+  (`HERDR_ENV=1`). Run remote attach in its own Ghostty tab.
+- **Version discipline**: the wire protocol refuses attach on ANY
+  client/server version mismatch. Mac and Linux must run the same
+  version and upgrade together (see Upgrades below). The `ssh` +
+  local `herdr` fallback always works regardless of skew.
+- herdr's prefix is `ctrl+a` — the same as remote tmux. Inside a
+  herdr pane, an inner tmux never sees the prefix. Reach remote tmux
+  from a plain Ghostty tab instead. (**⚠ verify** whether pressing
+  `ctrl+a` twice forwards a literal prefix.)
+
+## Install
+
+Mac:
+
+```bash
+brew install herdr && brew pin herdr   # pinned: upgrades are manual
+```
+
+Linux (**⚠ verify** the official installer URL on setup day):
+
+```bash
+curl -fsSL https://herdr.dev/install.sh | sh
+herdr --version    # MUST match the Mac version
+```
+
+Linux plugin dependencies (install first): `bun`, `fzf`, `jq`,
+`python3`, `cargo`, `nvim`, and `television` >= 0.15 via
+`cargo install television` — termscope's build step upgrades tv via
+Homebrew when missing (**verified** on Mac: it silently bumped
+0.14.4 → 0.15.9), and on Linux without brew it aborts instead.
+
+## Config
+
+Nothing to write on a new machine — it ships with the dotfiles:
+
+- `~/.config/herdr/config.toml##template` (tracked): `yadm alt`
+  generates `config.toml` on clone/pull. Only the `[experimental]`
+  block branches per OS (kitty graphics + CJK IME are Darwin-only).
+- Toast delivery is `system` (**verified**): toasts are posted by the
+  CLIENT side, so with `--remote` even remote agents' notifications
+  land in the local Mac's notification center.
+- Reload after changes: `herdr server reload-config` (edit the
+  template, run `yadm alt`, then reload).
+
+## Plugins (each machine, SHA-pinned)
+
+```bash
+herdr plugin install --yes paulbkim-dev/vim-herdr-navigation \
+  --ref 820d48f5d9c9a7dece6a4bebfa3982ec30bbfbb7
+herdr plugin install --yes andrewchng/herdr-sessionizer \
+  --ref 20827358a8da57b83d479cf899909bbf11919541
+herdr plugin install --yes iurysza/termscope \
+  --ref cbc6da8103c263343b7082e27e804cc91312f944
+herdr plugin install --yes NathanFlurry/herdr-plugin-jj-workspace \
+  --ref a9f1d3bcdaa2354e336a5173da85cbe4970c0f2e
+herdr plugin list
+```
+
+Version-control boundaries (**verified**):
+
+- `plugins/github/` = build artifacts (bun node_modules, cargo
+  target) — in `.yadmignore`, reinstall with the lines above
+- `plugins/config/` = plugin settings — yadm-tracked
+- Supply-chain hardening option: fork each repo and install
+  `nickboy/<repo> --ref <SHA>` (identical behavior); worth reviewing
+  termscope's `scripts/install-dependencies.sh` before install since
+  it touches the package manager
+
+Keybindings live in the main config (already set): `ctrl+hjkl`
+navigation, `prefix+f` / `prefix+shift+f` sessionizer,
+`prefix+u` / `prefix+shift+u` termscope (prefix-based on purpose —
+bare `ctrl+e/a` would steal readline keys), `prefix+shift+j` /
+`prefix+alt+j` jj workspaces. The jj **remove** action stays unbound:
+it runs `jj workspace forget` + `rm -rf` (untracked files gone) —
+action menu only.
+
+Sessionizer roots are machine-specific
+(`~/.config/herdr/plugins/config/sessionizer/config.toml`, tracked):
+this Mac uses `~/src`, `~/Workspace`, `~` with `git_only`. On a new
+machine with different project roots, either keep the same directory
+names or convert that config to a `##template` too. Known limits
+(**verified**): roots list children only (`~` itself and hidden dirs
+like `~/.claude` can never be candidates), no blacklist, preview is
+hard-coded `bat`/`ls`.
+
+## Claude Code integration (each machine)
+
+```bash
+herdr integration install claude
+yadm diff .claude/settings.json   # review, then commit if it changed
+```
+
+**Verified**: it merge-edits settings.json and preserves existing
+hooks (claude-notify, claude-name-session) and the statusline. Two
+fixups it needs every time it (re)writes: the hook command uses a
+hardcoded `/Users/...` path (change to `"$HOME/..."`), and the file
+loses its trailing newline. The generated hook script
+(`~/.claude/hooks/herdr-agent-state.sh`) is a machine artifact — do
+not track; rerun the integration command to regenerate.
+
+## Notifications: who does what
+
+| Path | Behavior |
+| --- | --- |
+| herdr pane (local or remote) | herdr agent engine → system toast |
+| Ghostty direct / tmux / SSH+tmux | claude-notify (OSC 9/777) as before |
+
+**Verified**: herdr consumes pane OSC 9/777 rather than forwarding
+them (the OSC 9 payload even pollutes the agent-progress display), so
+`claude-notify` stands down inside herdr panes (guard at the top of
+the script). Ghostty's `notify-on-command-finish` also never fires
+inside herdr panes (OSC 133 is consumed) — expected, covered by
+toasts.
+
+## Session titles on tabs
+
+Free with the dotfiles: `claude-name-session` mirrors the Claude
+session title onto the herdr tab (`herdr tab rename $HERDR_TAB_ID`) —
+the equivalent of the old tmux window rename. New sessions get the
+`project/branch` default; resumed sessions mirror their real title.
+Mid-session `/rename` syncs on the next resume (no hook event exists).
+
+## Daily entrypoints
+
+- Local: run `herdr` in a Ghostty tab (auto-starts the server).
+- Remote: `herdr --remote user@host`. **Verified from CLI help**:
+  `--remote-keybindings local` is the default — your local muscle
+  memory follows you. herdr's generated SSH config includes
+  `~/.ssh/config` first, so ProxyJump/ControlMaster/1Password agent
+  settings all apply.
+- The client does NOT auto-reconnect after a network drop (it exits
+  with a reattach hint). A retry wrapper for `.zshrc`, **⚠ verify
+  first** that a deliberate `prefix+q` detach exits 0 (detach once,
+  pull the network once, check `$?` both times):
+
+```bash
+hbox() {
+  while true; do
+    herdr --remote user@box "$@" && break
+    print "connection lost — retrying in 2s (Ctrl-C to stop)"
+    sleep 2
+  done
+}
+```
+
+- Fallback from anywhere: `ssh <host>` then plain `herdr` — same
+  binary, same version, always attaches.
+
+## Upgrades (both ends together, always manual)
+
+Daily maintenance never touches herdr (`brew pin`, enforced by a
+test-suite assertion). To upgrade, do both machines in one sitting:
+
+```bash
+brew unpin herdr && brew upgrade herdr && brew pin herdr
+ssh <host> 'curl -fsSL https://herdr.dev/install.sh | sh'
+herdr --version && ssh <host> 'herdr --version'   # must match
+```
+
+Then restart each server at a convenient moment
+(`herdr server stop`; next attach restores the layout and
+`claude --resume`s the agent panes — `resume_agents_on_restore`).
+
+## Day-1 verification checklist
+
+1. LazyVim diagnostics show colored undercurls in a herdr pane
+2. Shift+Enter inserts a newline in Claude Code
+3. `prefix+?` — walk the keymap, look for conflicts
+4. Remote: yank in a remote nvim → lands in the Mac clipboard
+   (OSC52 through the client — **⚠ verify**)
+5. Remote: let an agent block → macOS notification banner appears
+6. `hbox` exit-code semantics (see above)
+7. tmux + yazi image preview still works (general dev untouched)
+
+## Rollback
+
+`brew unpin herdr && brew uninstall herdr` (Mac), remove the Linux
+binary, `herdr integration uninstall claude` on both ends (**⚠
+verify** it removes only its own hook entries), revert the trial
+branch. tmux was never touched; Zellij retires only if herdr
+graduates.

--- a/docs/herdr-setup.md
+++ b/docs/herdr-setup.md
@@ -24,7 +24,10 @@ Rules learned the hard way:
   leaks `CLAUDECODE=1` into every pane and kills zoxide/`cd` (the
   .zshrc guard fires for user shells). `.zshrc` now clears a stale
   flag inside herdr panes, but the server should still be started by
-  a human running plain `herdr`. (**verified** — it happened.)
+  a human running plain `herdr` from a login shell, or auto-started
+  by the first attach. CLAUDECODE was merely the leaked variable that
+  got CAUGHT — a tool-shell server keeps handing every future pane
+  its whole polluted environment. (**verified** — it happened.)
 - **No nesting**: herdr inside a herdr pane is blocked by design
   (`HERDR_ENV=1`). Run remote attach in its own Ghostty tab.
 - **Version discipline**: the wire protocol refuses attach on ANY
@@ -214,6 +217,12 @@ herdr --version && ssh <host> 'herdr --version'   # must match
 Then restart each server at a convenient moment
 (`herdr server stop`; next attach restores the layout and
 `claude --resume`s the agent panes — `resume_agents_on_restore`).
+
+**Before any server stop**: it kills every pane, not just agents.
+Agent panes come back with their conversations; NON-agent panes
+(dev servers, `tail -f`, running downloads) restore as a fresh shell
+in the right directory only. Scan the sidebar and wind those down
+first.
 
 ## Day-1 verification checklist
 

--- a/docs/herdr-setup.md
+++ b/docs/herdr-setup.md
@@ -64,9 +64,13 @@ Nothing to write on a new machine — it ships with the dotfiles:
 - `~/.config/herdr/config.toml##template` (tracked): `yadm alt`
   generates `config.toml` on clone/pull. Only the `[experimental]`
   block branches per OS (kitty graphics + CJK IME are Darwin-only).
-- Toast delivery is `system` (**verified**): toasts are posted by the
-  CLIENT side, so with `--remote` even remote agents' notifications
-  land in the local Mac's notification center.
+- Toast delivery is `terminal` (**verified the hard way**): the client
+  asks its outer terminal (Ghostty) to post the banner. `system` looks
+  right on paper but macOS only has Ghostty registered in Notification
+  Center — herdr's system path (terminal-notifier/osascript) gets
+  silently dropped. `terminal` covers every topology: local, --remote
+  (client is local Ghostty), and ssh+herdr (OSC rides SSH back).
+  Banners appear only while Ghostty is unfocused (Ghostty's policy).
 - Reload after changes: `herdr server reload-config` (edit the
   template, run `yadm alt`, then reload).
 
@@ -130,8 +134,12 @@ not track; rerun the integration command to regenerate.
 
 | Path | Behavior |
 | --- | --- |
-| herdr pane (local or remote) | herdr agent engine → system toast |
+| herdr pane (local or remote) | herdr agent engine → Ghostty banner |
 | Ghostty direct / tmux / SSH+tmux | claude-notify (OSC 9/777) as before |
+
+Toasts fire on agent transitions to done/blocked; the ACTIVE tab is
+suppressed by design — staring at a finishing agent never banners.
+Sounds for background state changes are on by default (`[ui.sound]`).
 
 **Verified**: herdr consumes pane OSC 9/777 rather than forwarding
 them (the OSC 9 payload even pollutes the agent-progress display), so

--- a/docs/work-machine-checklist.md
+++ b/docs/work-machine-checklist.md
@@ -1,0 +1,85 @@
+# Work-Machine Deployment Checklist
+
+Deploying these dotfiles onto a machine that already has its own
+configuration (work laptop, corporate Mac). The repo is PUBLIC — the
+prime directive: **anything work-specific (internal endpoints, proxy,
+model names, internal tooling) goes in machine-local files only and
+is never committed.**
+
+## Before cloning
+
+- [ ] Back up existing Claude Code config — `yadm clone` will take
+  over `~/.claude/settings.json` and conflicts get messy after:
+
+  ```bash
+  cp -r ~/.claude ~/claude-backup-before-yadm
+  ```
+
+- [ ] Note any other dotfiles the machine already customizes
+  (`~/.zshrc`, `~/.gitconfig`, `~/.ssh/config`) — same reasoning.
+
+## Clone
+
+```bash
+# HTTPS works anonymously (no SSH agent on a fresh machine yet):
+yadm clone https://github.com/nickboy/dotfiles.git
+yadm status   # review conflicts/local modifications before anything else
+```
+
+Switch the remote to SSH only after an SSH key exists on the machine
+(see the README install section). On a work machine that may mean a
+work key, not 1Password.
+
+## Reconcile Claude Code settings
+
+Precedence (highest wins): managed-settings.json (MDM/org — never
+fight it) → `settings.local.json` (machine-local, gitignored) →
+`settings.json` (tracked, shared).
+
+- [ ] Merge work-required entries from the backup into
+  `~/.claude/settings.local.json`: auth/gateway (Bedrock, proxy,
+  `apiKeyHelper`), org permission policies, work-only plugins.
+- [ ] Model override: tracked settings pin a personal model; if the
+  work plan lacks access, set `model` in `settings.local.json`.
+- [ ] The tracked SessionStart hook
+  `~/.claude/hooks/herdr-agent-state.sh` is a herdr-generated
+  artifact. Either run `herdr integration install claude`
+  (see [herdr-setup.md](herdr-setup.md)) or expect a harmless hook
+  error each session until you do.
+
+## Git identity
+
+- [ ] `~/.gitconfig` is untracked by design — set the work name,
+  email, and signing there. Tracked config only carries neutral
+  defaults (osxkeychain, delta, zdiff3).
+- [ ] Do NOT copy the personal machine's signing setup; sign with a
+  work key or not at all. Tracked `~/.ssh/allowed_signers` holds
+  public keys only — harmless.
+
+## Homebrew
+
+- [ ] Review the Brewfile before `brew bundle` — it targets a
+  personal machine (spotify, iina, adguard, setapp, 1password casks).
+  Install selectively where MDM or policy applies.
+
+## Known gotchas (learned on the primary machine)
+
+- [ ] macOS notification permission is per-app: the first OSC 777
+  banner from Ghostty triggers a permission prompt — **allow it**,
+  or you get sound-but-no-banner. Verify registration with
+  `defaults read com.apple.ncprefs apps`.
+- [ ] `~/CLAUDE.md` applies to every Claude session under `~`. Its
+  git rules describe the personal setup (1Password SSH); if the work
+  machine uses enterprise hosting, flag it and make those sections
+  conditional rather than fighting them ad hoc.
+- [ ] herdr (if used): follow [herdr-setup.md](herdr-setup.md) —
+  version lockstep with any remote, server started from a clean
+  login shell, clients re-attach after toast-config changes.
+
+## Verify
+
+```bash
+bash ~/test-dotfiles.sh        # full local suite
+claude                          # starts without hook errors
+type cd                         # alias for z (zoxide active)
+```


### PR DESCRIPTION
## Summary

herdr 2-week trial, Day 0 + live-debugging round. Scope: **Claude Code sessions only** — tmux stays primary, Zellij untouched. 17 single-concern commits; every claim below was verified live.

### Foundation
- **herdr 0.7.5** installed, `brew pin`ned (wire protocol refuses attach on any version mismatch)
- **config as yadm `##template`**: one tracked template for every machine (work laptop / remote Linux later); `[experimental]` branches per OS. Generated file verified byte-equivalent on this Mac
- **4 plugins** commit-pinned; README documents `--ref` SHA reinstalls
- **claude integration**: settings.json merge verified line-by-line; hardcoded /Users path fixed to $HOME

### Muscle memory + UX
- ctrl+a prefix, backslash/minus splits, bare ctrl+hjkl vim navigation (tracked nvim after/plugin loader — glob-based, no vendored copy, no-op without herdr)
- sessionizer (prefix+f), termscope (prefix+u/U — bare ctrl keys would steal readline), jj workspaces (destructive remove deliberately unbound)
- **Session titles mirror onto herdr tabs** via claude-name-session (the tmux window-rename equivalent); resume path mirrors existing titles without overwriting

### Bugs found & fixed during live use
- **CLAUDECODE leak**: a server started from a Claude tool shell hands every pane its polluted env, killing the cd→zoxide alias. .zshrc now clears the stale flag inside herdr panes; rule documented: server starts from a clean login shell only
- **Notifications**: herdr eats pane OSC 9/777 (claude-notify now stands down inside herdr panes), and macOS only has Ghostty registered in Notification Center — so toast delivery is `terminal` (Ghostty posts; works for local, --remote, and ssh+herdr). Client reads toast config at ATTACH — reload-config never updates a running client (documented in troubleshooting)

### Docs
- **docs/herdr-setup.md**: dual-machine setup guide (Mac + remote Linux) — install, SHA-pinned plugins, notification design, hbox reconnect recipe, upgrade lockstep discipline, day-1 checklist, no-banner troubleshooting, rollback. Unverified items flagged ⚠ for setup day
- Skills purge: dotfiles-shell (scooter, session-manager v1.1.0 semantics), dotfiles-commit (1Password signing + SSH-only push rules), README clone flow (HTTPS→SSH switch)
- ssh: github.com routed through the 1Password agent

## Post-merge owner steps
1. `herdr server stop`, then `herdr` from a fresh Ghostty tab (clean server + new client). Scan sidebar first — non-agent pane processes don't survive
2. Verify: `type cd` → alias for z; tab shows the session title on resume; banner test with Ghostty unfocused

## Trial verdict ~Aug 16
sidebar reduces tab-patrolling? / update bit a session? / orchestration got real use? 2 of 3 → graduate (retire sesh, resurrect/continuum, Zellij); else uninstall, revisit at 1.0