### PR TITLE
docs(checklist): update path for machines already running yadm

### DIFF
--- a/docs/work-machine-checklist.md
+++ b/docs/work-machine-checklist.md
@@ -6,7 +6,51 @@ prime directive: **anything work-specific (internal endpoints, proxy,
 model names, internal tooling) goes in machine-local files only and
 is never committed.**
 
-## Before cloning
+Two paths: **update** (yadm already set up with an older version of
+this repo — most common) or **fresh clone**. Update path first.
+
+## Update path (yadm already installed)
+
+- [ ] Assess before pulling:
+
+  ```bash
+  yadm log --oneline -1     # how far behind
+  yadm status               # LOCAL modifications to tracked files?
+  yadm diff                 # review them — this is the conflict risk
+  ```
+
+- [ ] Local modifications to tracked files (settings.json is the
+  usual suspect) block or conflict the pull. Move work-specific
+  values into `~/.claude/settings.local.json`, then either commit
+  keepers on a branch or discard: `yadm checkout -- <file>`.
+- [ ] Pull (HTTPS pull works anonymously on this public repo):
+
+  ```bash
+  yadm pull
+  yadm alt          # regenerate templates (plist, herdr config)
+  ```
+
+- [ ] Post-pull migration (delta since mid-2026 versions):
+  - `yadm bootstrap` — idempotent; installs TPM/pay-respects/etc.
+  - `brew bundle --file=~/Brewfile` selectively (`gitleaks` matters:
+    the pre-commit hook uses it; it skips with a warning if absent)
+  - tmux: `prefix+I` to sync plugins;
+    tmux-claude-session-manager >= 1.1.0 reads status from
+    `claude agents` — the old state.sh hooks are gone from
+    settings.json, never re-add them
+  - Reconcile `~/.claude/settings.json` with the backup (work model /
+    auth → settings.local.json; herdr SessionStart hook warns
+    harmlessly until `herdr integration install claude` or herdr is
+    skipped entirely)
+  - `bash ~/test-dotfiles.sh` — the suite is the cross-machine
+    verification of the whole update
+- [ ] Push transport for THIS machine: keep HTTPS +
+  `gh auth login`, or a work SSH key — set in the machine's untracked
+  `~/.gitconfig`. Do not copy the personal 1Password setup.
+
+## Fresh-clone path
+
+### Before cloning
 
 - [ ] Back up existing Claude Code config — `yadm clone` will take
   over `~/.claude/settings.json` and conflicts get messy after:
@@ -18,7 +62,7 @@ is never committed.**
 - [ ] Note any other dotfiles the machine already customizes
   (`~/.zshrc`, `~/.gitconfig`, `~/.ssh/config`) — same reasoning.
 
-## Clone
+### Clone
 
 ```bash
 # HTTPS works anonymously (no SSH agent on a fresh machine yet):
@@ -30,7 +74,7 @@ Switch the remote to SSH only after an SSH key exists on the machine
 (see the README install section). On a work machine that may mean a
 work key, not 1Password.
 
-## Reconcile Claude Code settings
+### Reconcile Claude Code settings
 
 Precedence (highest wins): managed-settings.json (MDM/org — never
 fight it) → `settings.local.json` (machine-local, gitignored) →


### PR DESCRIPTION
The work laptop already runs an older version of these dotfiles — the common case is pull-and-migrate, not fresh clone. Adds the update path: assess local modifications first, anonymous-HTTPS pull, post-pull migration (bootstrap, selective brew bundle incl. gitleaks, tmux plugin sync, session-manager 1.1.0 semantics), test-dotfiles.sh as cross-machine verification, per-machine push transport.