### PR TITLE
feat(maintenance): unpin herdr + live-server strand detection

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -157,8 +157,10 @@ brew "yazi"
 # Terminal multiplexer (modern tmux alternative)
 brew "zellij"
 # AI-agent-aware multiplexer — 2-week trial for Claude Code sessions.
-# brew-pinned during the trial: protocol-version mismatch refuses attach,
-# so upgrades must be deliberate (unpin or `herdr update` when chosen).
+# UNPINNED on purpose (owner tracks every release; fast-moving upstream).
+# Its wire protocol refuses attach across versions, so daily-maintenance
+# detects a bump landing on a live server and notifies instead of killing
+# it — restart when convenient; agent panes resume natively.
 brew "herdr"
 # Shell extension to navigate your filesystem faster
 brew "zoxide"

--- a/README.md
+++ b/README.md
@@ -791,8 +791,12 @@ zjd             # zellij delete-session
 
 [herdr](https://herdr.dev/) is an AI-agent-aware multiplexer under a
 two-week trial for Claude Code sessions only — tmux stays primary.
-Formula is `brew pin`ned (its wire protocol refuses attach across any
-version mismatch). Config: `~/.config/herdr/config.toml` (ctrl+a
+The formula is unpinned on purpose — every release is picked up by the
+daily maintenance. Its wire protocol refuses attach across versions,
+so the maintenance run detects an upgrade landing on a live server and
+sends a notification instead of killing it: restart when convenient
+(`herdr server stop`, then `herdr`; agent panes resume natively).
+Config: `~/.config/herdr/config.toml` (ctrl+a
 prefix, tmux-mirrored keys, Catppuccin). Plugins are machine-local;
 on a new machine install them SHA-pinned (small third-party repos —
 the `--ref` pin is the supply-chain guard):

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -767,8 +767,11 @@ zjd             # zellij delete-session
 ## herdr（試驗中）
 
 [herdr](https://herdr.dev/) 是感知 AI agent 狀態的多工器，目前進行
-兩週試驗——只承載 Claude Code session，tmux 仍是主力。formula 已
-`brew pin`（其協定在任何版本不匹配時拒絕 attach）。設定在
+兩週試驗——只承載 Claude Code session，tmux 仍是主力。formula
+刻意**不釘版**——每日維護會跟上每個 release。其協定在版本不匹配時
+拒絕 attach，因此維護腳本偵測到「升級落在活著的 server 上」時會發
+桌面通知而非殺掉它：方便時再重啟（`herdr server stop` 後 `herdr`，
+agent pane 會原生 resume）。設定在
 `~/.config/herdr/config.toml`（ctrl+a prefix、對映 tmux 鍵位、
 Catppuccin）。插件屬機器本地產物；新機器以 SHA 釘版安裝
 （皆為小型第三方 repo，`--ref` 是供應鏈防護）：

--- a/daily-maintenance-lib.sh
+++ b/daily-maintenance-lib.sh
@@ -82,3 +82,13 @@ dm_load() {
 dm_unload() {
     launchctl bootout "$DM_DOMAIN/$DM_LABEL"
 }
+
+# Pure predicate: did a herdr version bump land while a server is live?
+# $1 = version before upgrade, $2 = after, $3 = socket path override
+# (defaults to the real socket). No side effects — the caller decides
+# how to notify. Unit-tested in test-dotfiles.sh.
+dm_herdr_strand_detected() {
+    local before="$1" after="$2"
+    local sock="${3:-$HOME/.config/herdr/herdr.sock}"
+    [ -n "$before" ] && [ "$before" != "$after" ] && [ -S "$sock" ]
+}

--- a/daily-maintenance.sh
+++ b/daily-maintenance.sh
@@ -325,8 +325,30 @@ FAILED_COMMANDS=()
 # Run your daily maintenance commands
 # 900s timeout: a stalled network otherwise hangs the whole run (the other
 # network steps are already wrapped; brew was the only unguarded one)
+# herdr is deliberately UNPINNED (owner wants every release): capture its
+# version before the upgrade so a bump can be detected afterwards.
+# 'herdr --version' reads the binary only — it never auto-starts a server.
+HERDR_VERSION_BEFORE="$(herdr --version 2>/dev/null || true)"
 if ! run_command "Homebrew formula upgrade" run_with_timeout 900 brew upgrade --yes; then
     FAILED_COMMANDS+=("brew upgrade")
+fi
+
+# herdr's wire protocol refuses attach on ANY version mismatch, so a bump
+# strands a still-running server. NEVER kill it here — the owner may be in
+# a live session, and no herdr CLI may be called (it could auto-start a
+# server that inherits this launchd environment). Detect via the socket
+# and notify; agent panes resume natively after the owner restarts.
+HERDR_VERSION_AFTER="$(herdr --version 2>/dev/null || true)"
+if [ -n "$HERDR_VERSION_BEFORE" ] \
+    && [ "$HERDR_VERSION_BEFORE" != "$HERDR_VERSION_AFTER" ] \
+    && [ -S "$HOME/.config/herdr/herdr.sock" ]; then
+    echo "herdr upgraded ($HERDR_VERSION_BEFORE -> $HERDR_VERSION_AFTER) with a live server."
+    echo "Attach will be refused until the server restarts (herdr server stop; herdr)."
+    if command -v terminal-notifier >/dev/null 2>&1; then
+        terminal-notifier -title "herdr upgraded" \
+            -message "Server still on $HERDR_VERSION_BEFORE. When convenient: herdr server stop, then herdr (agents auto-resume)." \
+            >/dev/null 2>&1 || true
+    fi
 fi
 
 # Self-heal: remove leftover *.upgrading cask staging dirs from a previously

--- a/daily-maintenance.sh
+++ b/daily-maintenance.sh
@@ -84,6 +84,11 @@ echo "========================================="
 # Set up PATH to include homebrew
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 
+# Shared helpers (dm_herdr_strand_detected lives here so it can be
+# unit-tested by test-dotfiles.sh)
+# shellcheck source=daily-maintenance-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/daily-maintenance-lib.sh"
+
 # Set up timeout command (macOS uses gtimeout from coreutils)
 if command -v gtimeout >/dev/null 2>&1; then
     TIMEOUT_CMD="gtimeout"
@@ -339,9 +344,7 @@ fi
 # server that inherits this launchd environment). Detect via the socket
 # and notify; agent panes resume natively after the owner restarts.
 HERDR_VERSION_AFTER="$(herdr --version 2>/dev/null || true)"
-if [ -n "$HERDR_VERSION_BEFORE" ] \
-    && [ "$HERDR_VERSION_BEFORE" != "$HERDR_VERSION_AFTER" ] \
-    && [ -S "$HOME/.config/herdr/herdr.sock" ]; then
+if dm_herdr_strand_detected "$HERDR_VERSION_BEFORE" "$HERDR_VERSION_AFTER"; then
     echo "herdr upgraded ($HERDR_VERSION_BEFORE -> $HERDR_VERSION_AFTER) with a live server."
     echo "Attach will be refused until the server restarts (herdr server stop; herdr)."
     if command -v terminal-notifier >/dev/null 2>&1; then

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -136,6 +136,14 @@ echo -e "${YELLOW}7. Common Issues Check${NC}"
 
 # Check for hardcoded paths that might not exist
 run_test "No hardcoded /Users/specific paths" "! grep -r '/Users/[^/]*/' *.sh | grep -v '\$HOME' | grep -v nickboy"
+# uv's installer drops a PATH snippet at ~/.local/bin/env meant to be
+# SOURCED; if it ever becomes executable it shadows /usr/bin/env (PATH
+# puts ~/.local/bin second) and silently swallows every 'env ... cmd'
+# invocation with exit 0. That exact trap cost a debugging session.
+run_test "env resolves to /usr/bin/env (no executable shim)" \
+    "[ \"\$(command -v env)\" = /usr/bin/env ]"
+run_test "No ~/.local/bin executables shadow system binaries" \
+    "! (for f in \$HOME/.local/bin/*; do b=\$(basename \"\$f\"); [ -x \"\$f\" ] && { [ -e \"/usr/bin/\$b\" ] || [ -e \"/bin/\$b\" ]; } && echo \"\$b\"; done | grep -q .)"
 
 # Check for proper shebang
 for script in *.sh; do
@@ -194,6 +202,16 @@ if [ -f "$HOME/daily-maintenance.sh" ]; then
     # (a July 2026 incident deleted VS Code that way).
     run_test "Maintenance cask upgrade never uses greedy/auto-updates" \
         "! grep -E 'brew upgrade' $HOME/daily-maintenance.sh | grep -qE -- '--greedy(-auto-updates)?([[:space:]]|\$)'"
+    # Tripwire: the maintenance run must never call the herdr CLI beyond
+    # --version — any other subcommand can auto-start a server that
+    # inherits the launchd environment (the CLAUDECODE-leak bug class).
+    # Allowed matches: --version calls, echo/notifier message strings,
+    # the socket path. Anything else fails.
+    run_test "Maintenance calls herdr CLI only with --version" \
+        "! grep -E '^[^#]*\\bherdr\\b' $HOME/daily-maintenance.sh | grep -v -e '--version' -e echo -e terminal-notifier -e '\\-message' -e '\\.sock' | grep -q ."
+    # The strand guard depends on the shared lib being sourced.
+    run_test "Maintenance sources daily-maintenance-lib.sh" \
+        "grep -qE '^source .*daily-maintenance-lib.sh' $HOME/daily-maintenance.sh && grep -q 'dm_herdr_strand_detected' $HOME/daily-maintenance.sh"
 fi
 echo
 
@@ -253,6 +271,23 @@ if [ -f "$HOME/.config/sesh/sesh.toml" ]; then
     # chain AND stale-cache confusion.
     run_test "Zellij zjstatus plugin URL is version-pinned" \
         "grep -qE 'zjstatus/releases/download/v[0-9]+\.[0-9]+\.[0-9]+/zjstatus\.wasm' $HOME/.config/zellij/layouts/default.kdl"
+    if command -v zellij >/dev/null 2>&1; then
+        run_test "Zellij config + layouts parse (setup --check)" \
+            "zellij setup --check >/dev/null 2>&1"
+    fi
+    # Yazi 26 broke silently on a stale fetchers schema (id -> group):
+    # --version fails when the config no longer parses, so this catches
+    # the next schema break instead of yazi quietly using preset config.
+    if command -v yazi >/dev/null 2>&1; then
+        run_test "Yazi config parses (yazi --version)" \
+            "yazi --version >/dev/null 2>&1"
+    fi
+    if [ -f "$HOME/.config/herdr/config.toml" ]; then
+        run_test "herdr config TOML valid" "python3 -c \"import tomllib, pathlib; tomllib.loads(pathlib.Path('$HOME/.config/herdr/config.toml').read_text())\""
+    fi
+    if [ -f "$HOME/.config/herdr/plugins/config/sessionizer/config.toml" ]; then
+        run_test "herdr sessionizer config TOML valid" "python3 -c \"import tomllib, pathlib; tomllib.loads(pathlib.Path('$HOME/.config/herdr/plugins/config/sessionizer/config.toml').read_text())\""
+    fi
 fi
 echo
 
@@ -280,6 +315,17 @@ echo -e "${YELLOW}11. Security Checks${NC}"
 # No secrets in yadm-tracked files
 if command -v yadm >/dev/null 2>&1; then
     run_test "No secrets in tracked files" "[ -z \"\$(yadm list -a 2>/dev/null | xargs grep -lE '(APIKEY|SECRET_KEY|API_TOKEN|PRIVATE_KEY|TOKEN|PASSWORD|CREDENTIAL|AWS_SECRET)\s*=' 2>/dev/null | grep -v 'HOMEBREW_NO_ANALYTICS' | grep -v 'test-dotfiles.sh')\" ]"
+fi
+# Commit signing depends on allowed_signers carrying a public key
+if [ -f "$HOME/.ssh/allowed_signers" ]; then
+    run_test "allowed_signers contains an SSH public key" \
+        "grep -qE 'ssh-(rsa|ed25519) ' $HOME/.ssh/allowed_signers"
+fi
+# Every checkout in CI must set persist-credentials: false (zizmor
+# artipacked); count parity catches a new checkout step added without it.
+if [ -f "$HOME/.github/workflows/ci.yml" ]; then
+    run_test "CI checkouts all set persist-credentials false" \
+        "[ \"\$(grep -c 'uses: actions/checkout@' $HOME/.github/workflows/ci.yml)\" -eq \"\$(grep -c 'persist-credentials: false' $HOME/.github/workflows/ci.yml)\" ]"
 fi
 echo
 
@@ -335,6 +381,59 @@ if command -v shellcheck >/dev/null 2>&1; then
     fi
 else
     echo -e "${YELLOW}  ShellCheck not installed; skipping${NC}"
+fi
+echo
+
+# Test 15: Unit tests (lib functions + fixture-based checks)
+echo -e "${YELLOW}15. Unit Tests${NC}"
+
+# dm_herdr_strand_detected: pure predicate from daily-maintenance-lib.sh.
+# A real unix socket is required for the -S branch; python3 binds one in
+# a temp dir so all four polarities are exercised.
+if [ -f "$HOME/daily-maintenance-lib.sh" ]; then
+    HERDR_UT_DIR=$(mktemp -d)
+    python3 -c "import socket; socket.socket(socket.AF_UNIX).bind('$HERDR_UT_DIR/live.sock')" 2>/dev/null
+    UT_SRC="source '$HOME/daily-maintenance-lib.sh' >/dev/null 2>&1;"
+    # macOS caps unix socket paths at ~104 bytes; if the bind failed
+    # (long CI temp dir), skip the two socket-positive cases instead of
+    # reporting a false failure.
+    if [ -S "$HERDR_UT_DIR/live.sock" ]; then
+        run_test "herdr strand: mismatch + live socket -> detected" \
+            "bash -c \"$UT_SRC dm_herdr_strand_detected 'herdr 1.0' 'herdr 2.0' '$HERDR_UT_DIR/live.sock'\""
+        run_test "herdr strand: same version -> silent" \
+            "bash -c \"$UT_SRC ! dm_herdr_strand_detected 'herdr 1.0' 'herdr 1.0' '$HERDR_UT_DIR/live.sock'\""
+    else
+        echo -e "  ${YELLOW}ℹ️  unix socket bind unavailable; skipping socket-positive cases${NC}"
+    fi
+    run_test "herdr strand: no socket -> silent" \
+        "bash -c \"$UT_SRC ! dm_herdr_strand_detected 'herdr 1.0' 'herdr 2.0' '$HERDR_UT_DIR/missing.sock'\""
+    run_test "herdr strand: herdr absent (empty before) -> silent" \
+        "bash -c \"$UT_SRC ! dm_herdr_strand_detected '' 'herdr 2.0' '$HERDR_UT_DIR/live.sock'\""
+    rm -rf "$HERDR_UT_DIR"
+fi
+
+# gitleaks pre-commit engine: same invocation the yadm hook uses, against
+# a throwaway fixture repo (plain git on purpose — the yadm-only rule is
+# for the dotfiles repo, not isolated fixtures). The canary is assembled
+# at runtime so no secret-shaped literal exists in this file (a literal
+# would trip GitHub push protection and the hook's own scan).
+# CRITICAL: every call strips GIT_DIR/GIT_WORK_TREE — the yadm pre_commit
+# hook exports them, and an ambient GIT_DIR silently redirects fixture
+# git commands at the REAL yadm repo (this once flipped its core.bare).
+if command -v gitleaks >/dev/null 2>&1 && command -v git >/dev/null 2>&1; then
+    GL_TMP=$(mktemp -d)
+    GL_GIT="env -u GIT_DIR -u GIT_WORK_TREE git"
+    $GL_GIT -C "$GL_TMP" init -q &&
+        $GL_GIT -C "$GL_TMP" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+    printf 'aws_key = "%s%s"\n' "AKIA" "ZZZQK9X2M4P7L3TQ" > "$GL_TMP/leak.txt"
+    $GL_GIT -C "$GL_TMP" add leak.txt
+    run_test "gitleaks flags a staged canary secret" \
+        "! (cd '$GL_TMP' && env -u GIT_DIR -u GIT_WORK_TREE gitleaks git --pre-commit --staged --no-banner --redact . >/dev/null 2>&1)"
+    printf 'greeting = "hello"\n' > "$GL_TMP/leak.txt"
+    $GL_GIT -C "$GL_TMP" add leak.txt
+    run_test "gitleaks passes a clean staged file" \
+        "(cd '$GL_TMP' && env -u GIT_DIR -u GIT_WORK_TREE gitleaks git --pre-commit --staged --no-banner --redact . >/dev/null 2>&1)"
+    rm -rf "$GL_TMP"
 fi
 echo
 


### PR DESCRIPTION
## Summary

Owner call: herdr should track every upstream release (fast-moving project), so the `brew pin` is removed and the daily maintenance now upgrades it like everything else.

The pin's safety job is replaced by detection instead of prevention:

- capture `herdr --version` before/after the formula upgrade step
- if the version changed **and** the server socket is live, print to the log and send a desktop notification: restart when convenient (`herdr server stop`, then `herdr`) — Claude panes resume natively
- the run **never kills the server** (a live session may be attached at 9 AM) and **never calls the herdr CLI beyond `--version`** (any other call can auto-start a server that inherits the launchd environment — the CLAUDECODE-leak class of bug)

Guard logic tested both ways: mismatch + live socket triggers; same version stays silent. Brewfile and README (en/zh) pin wording updated to match.

## Context

herdr's wire protocol refuses attach across ANY version difference, so an unattended upgrade landing on a running server strands the next attach. This PR makes that a notified, owner-paced restart instead of a morning surprise.