### PR TITLE
feat(ghostty): text-quality settings for the translucent background

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -29,6 +29,17 @@ background-opacity-cells = true
 background-blur-radius = 15
 macos-titlebar-style = tabs
 
+# Text quality on the translucent background (macOS default is native).
+# linear-corrected removes the darkening artifacts at glyph edges while
+# looking near-identical to native. Custom shaders receive colors in this
+# space — cursor_slash/cursor_smear were eyeballed after the switch.
+alpha-blending = linear-corrected
+# WCAG-ratio floor: only kicks in when fg/bg would be near-invisible
+minimum-contrast = 1.1
+# SGR faint/dim text (Starship, eza, bat) was too washed out at 0.82
+# opacity; default is 0.5
+faint-opacity = 0.7
+
 # Cursor settings
 cursor-style = block
 cursor-style-blink = true
@@ -108,6 +119,9 @@ auto-update-channel = tip
 
 # Additional features
 confirm-close-surface = false
+# Partner to confirm-close-surface=false: closing is undoable (Cmd+Z)
+# instead of confirmed. Default 5s is too short to notice a mistake.
+undo-timeout = 30s
 
 # Bell: dock bounce (when unfocused) + bell emoji in title
 # Note: system and audio are Linux/GTK-only, not functional on macOS

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -315,6 +315,13 @@ if [ -f "$HOME/.config/starship.toml" ]; then
     # (ssh-env is the wrong tool: it downgrades TERM to xterm-256color)
     run_test "Ghostty shell integration includes ssh-terminfo" \
         "grep -E '^shell-integration-features' $HOME/.config/ghostty/config | grep -q 'ssh-terminfo'"
+    # Deliberate text-quality choices for the 0.82-opacity background
+    # (2026-08 tip audit) — guard against accidental reversion
+    run_test "Ghostty translucency text-quality settings present" \
+        "grep -q '^alpha-blending = linear-corrected' $HOME/.config/ghostty/config && \
+         grep -q '^minimum-contrast = 1.1' $HOME/.config/ghostty/config && \
+         grep -q '^faint-opacity = 0.7' $HOME/.config/ghostty/config && \
+         grep -q '^undo-timeout = 30s' $HOME/.config/ghostty/config"
     # Daily bob-nightly + plugin churn can desync editor and plugins
     # (the neo-tree/nvim_win_resize incident: nvim frozen on a June
     # nightly while plugins assumed a newer API) — a clean headless


### PR DESCRIPTION
Adopts four options from the latest external Ghostty research round, every one verified against the local tip binary (`1.3.2-main-+d0659ba52`, `+show-config --default --docs`) before adoption.

## Adopted

| Option | Why |
|--------|-----|
| `alpha-blending = linear-corrected` | Removes glyph-edge darkening artifacts on the 0.82-opacity background; near-identical to native otherwise. Cursor shaders receive colors in this space — eyeball slash+smear after reload. |
| `minimum-contrast = 1.1` | WCAG-ratio floor; the documented anti-invisible-text insurance value. Only intervenes near 1:1 contrast. |
| `faint-opacity = 0.7` | SGR faint/dim text (Starship, eza, bat) washed out at 0.82 opacity; default 0.5. |
| `undo-timeout = 30s` | Partner to `confirm-close-surface = false`: undoable-close replaces confirm-close. Default 5s. |

## Rejected (fact-check)

- `app-notifications` — docs say GTK-only, no effect on macOS
- `quick-terminal-space-behavior = move`, `scroll-to-bottom` — already the defaults
- `command-palette-entry` — actions are keybind actions only, can't run shell commands
- secure-input pair — already on by default

Notably, the research's own "corrections" were wrong: `split-inherit-working-directory`, `tab-inherit-working-directory`, and `scrollbar` all exist in the tip binary (verified in the pure-defaults dump).

## Validation

- `ghostty +validate-config` clean
- New suite guard next to the ssh-terminfo check (all four keys asserted)
- Full suite green (114 checks)