### PR TITLE
feat(tmux): pin vi copy mode + v/C-v — align keybind contract with herdr

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -65,6 +65,15 @@ set -g renumber-windows on
 # Ghostty's 25MB. 50k lines keeps long build/agent logs reachable.
 set -g history-limit 50000
 
+# Copy mode (prefix+[): pin vi keys explicitly — the vi default here is
+# an accident of EDITOR=nvim, and a machine/context without that env
+# silently falls back to emacs. v/C-v add vim muscle memory on top
+# (stock vi mode only has Space/Enter); y stays with tmux-yank.
+# Same prefix+[ entry and vi motions as herdr's built-in copy mode.
+set -g mode-keys vi
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi C-v send -X rectangle-toggle
+
 bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -70,7 +70,17 @@ columns, so shared muscle memory and divergences both stand out.
 | `prefix+shift+j` | — | New jj workspace |
 | `prefix+alt+j` | — | New jj workspace (new tab) |
 | `prefix+1..9` | Switch to window N (default) | Switch to tab N (default) |
+| `prefix+[` | Copy mode, vi keys | Copy mode, vi keys (default) |
 | `F12` | Toggle nested/outer tmux | — |
+
+Copy mode is the same in both tools: `prefix+[` to enter, then vim
+motions (`h/j/k/l`, `w/b/e`, `0/^/$`, `{`/`}`, `g/G`), `/`+`n/N` to
+search, `v` to start a selection (`V` whole line), `y` to copy and
+exit, `q` to leave without copying. tmux additionally has `C-v` for
+rectangle selection. For structured strings (paths, URLs, hashes)
+skip copy mode entirely: `prefix+F` (tmux thumbs) or `prefix+u`/
+`prefix+shift+u` (herdr termscope) hint-pick them in one keystroke,
+and Ghostty's `cmd+f` searches the scrollback directly.
 
 Notes on divergences:
 

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -309,6 +309,11 @@ if [ -f "$HOME/.config/starship.toml" ]; then
             "tmux -L cfgtest-suite -f $HOME/.tmux.conf new-session -d 2>/dev/null && tmux -L cfgtest-suite kill-server 2>/dev/null"
         run_test "Tmux history-limit >= 50000" \
             "grep -qE 'history-limit (5[0-9]{4,}|[6-9][0-9]{4}|[0-9]{6,})' $HOME/.tmux.conf"
+        # vi copy mode must be pinned in config, not inherited from
+        # EDITOR=nvim — a shell without that env falls back to emacs
+        run_test "Tmux copy mode pinned to vi keys" \
+            "grep -q 'mode-keys vi' $HOME/.tmux.conf && \
+             grep -q 'copy-mode-vi v send -X begin-selection' $HOME/.tmux.conf"
     fi
     # ssh-terminfo (not ssh-env) keeps TERM intact on remotes — herdr's
     # terminal-notification detection over SSH depends on it


### PR DESCRIPTION
Keyboard selection instead of mouse. Fact-checked the external research round first — 2 of its 3 claims were wrong in an instructive way:

## Fact-check

| Claim | Verdict |
|---|---|
| herdr copy mode: `prefix+[`, full vim keys, zero config | ✅ Source-verified in `copy_mode.rs` (h/j/k/l, w/b/e, 0/^/$, {}, g/G, v/V, /?nN, y, q, C-u/d/b/f). Upstream even has a test `copy_mode_uses_tmux_prefix_bracket_by_default`. |
| tmux copy mode "is emacs — mode-keys vi missing" | ❌ Live server already shows `mode-keys vi` — tmux's documented fallback when `EDITOR` contains `vi` (ours is nvim). But the implicitness IS a real fragility, and stock vi mode lacks `v`/`C-v`. |
| "termscope not installed, tmux needs tmux-thumbs" | ❌ Both already installed: termscope at `prefix+u`/`prefix+shift+u` (SHA-pinned, deliberately remapped), tmux-thumbs at `prefix+F`. |

## Changes

- **.tmux.conf**: pin `mode-keys vi` explicitly (no longer dependent on the EDITOR accident) + `v` begin-selection, `C-v` rectangle-toggle. `y` deliberately not bound — tmux-yank owns it.
- **docs/keybindings.md**: new Layer 2 contract row `prefix+[` (identical in both multiplexers) + a copy-mode primer and routing note for the three selection layers (copy mode / hint pick / Ghostty `cmd+f` search).
- **test-dotfiles.sh**: guard asserting vi mode is pinned in config, not inherited from env.

## Validation

- Live-reloaded: `mode-keys vi`, both bindings present in `list-keys -T copy-mode-vi`
- Full suite green (115 checks), markdownlint clean