### PR TITLE
feat(copy): keyboard copy for shell output and Claude replies

### DIFF
--- a/.local/bin/claude-copy-last
+++ b/.local/bin/claude-copy-last
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# claude-copy-last — copy Claude's latest reply from the session
+# transcript, no screen selection involved.
+#
+# The Claude app has a per-message copy button; a terminal only has the
+# rendered screen. But Claude Code writes every message to
+# ~/.claude/projects/<slug>/<session>.jsonl, so the ORIGINAL markdown is
+# always on disk — reading it from there works identically in tmux,
+# herdr, or bare Ghostty, unaffected by scrollback, wrapping, or theme.
+#
+# Usage: claude-copy-last [-n N] [-c]
+#   -n N   N-th most recent assistant message (default 1 = latest);
+#          handy when the latest entry is a question back to you
+#   -c     always copy to clipboard, print nothing (for tmux run-shell,
+#          where stdout is not a tty)
+#
+# On a tty: copies to clipboard and prints a one-line preview.
+# Piped/redirected: raw markdown to stdout (ccl | glow, ccl > notes.md).
+#
+# CAVEAT: the transcript JSONL is Claude Code internal format with no
+# compatibility guarantee — tracked in docs/upgrade-watch.md; the test
+# suite asserts extraction against a fixture so schema drift is caught.
+
+set -euo pipefail
+
+# tmux run-shell and other minimal contexts may lack the brew PATH (jq)
+case ":$PATH:" in
+  *:/opt/homebrew/bin:*) ;;
+  *) PATH="/opt/homebrew/bin:$PATH" ;;
+esac
+
+n=1
+copy=auto
+while getopts "n:ch" opt; do
+    case "$opt" in
+        n) n="$OPTARG" ;;
+        c) copy=always ;;
+        h)
+            sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) exit 2 ;;
+    esac
+done
+
+case "$n" in
+    '' | *[!0-9]* | 0)
+        echo "claude-copy-last: -n takes a positive integer" >&2
+        exit 2
+        ;;
+esac
+
+projects_root="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
+
+# Claude Code slugs the launch cwd by replacing every non-alphanumeric
+# character with '-' (verified against real dirs under ~/.claude/projects).
+# Sessions are keyed to the cwd where claude was launched, so walk up
+# from $PWD until a project dir that actually has transcripts exists —
+# this is what keeps concurrent agents in other projects from bleeding
+# in: the pane's own cwd decides which transcript is read.
+dir="$PWD"
+proj=""
+while :; do
+    slug=$(printf '%s' "$dir" | sed 's/[^A-Za-z0-9]/-/g')
+    if ls "$projects_root/$slug"/*.jsonl >/dev/null 2>&1; then
+        proj="$projects_root/$slug"
+        break
+    fi
+    [ "$dir" = "/" ] && break
+    dir=$(dirname "$dir")
+done
+
+if [ -z "$proj" ]; then
+    echo "claude-copy-last: no Claude transcripts for $PWD (or parents)" >&2
+    exit 1
+fi
+
+# Newest transcript = the active / most recent session for this project
+# shellcheck disable=SC2012  # slug dirs + uuid names, no odd characters
+transcript=$(ls -t "$proj"/*.jsonl | head -1)
+
+# Sidechain entries are subagent traffic, not the conversation. One turn
+# can hold several text blocks (status notes between tool calls); each
+# counts as one step of -n, latest first. tail bounds the jq parse.
+msg=$(tail -n 5000 "$transcript" | jq -rs --argjson n "$n" '
+    [.[]
+     | select(.type == "assistant" and (.isSidechain != true))
+     | [.message.content[]? | select(.type == "text") | .text]
+     | select(length > 0)
+     | join("\n")]
+    | if length < $n then "" else .[length - $n] end')
+
+if [ -z "$msg" ]; then
+    echo "claude-copy-last: no assistant message (n=$n) in ${transcript##*/}" >&2
+    exit 1
+fi
+
+if [ "$copy" = always ]; then
+    printf '%s' "$msg" | pbcopy
+elif [ -t 1 ]; then
+    printf '%s' "$msg" | pbcopy
+    first_line=$(printf '%s' "$msg" | head -n 1)
+    printf 'copied %s chars from %s\n' "${#msg}" "${transcript##*/}"
+    printf '%.100s…\n' "$first_line"
+else
+    printf '%s\n' "$msg"
+fi

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -73,6 +73,21 @@ set -g history-limit 50000
 set -g mode-keys vi
 bind -T copy-mode-vi v send -X begin-selection
 bind -T copy-mode-vi C-v send -X rectangle-toggle
+# ( / ): hop between shell prompts (OSC 133 marks from Ghostty's zsh
+# integration — verified to survive into tmux panes)
+bind -T copy-mode-vi ( send -X previous-prompt
+bind -T copy-mode-vi ) send -X next-prompt
+
+# prefix+P: copy the previous shell command's complete output. Shell
+# commands only — Claude's TUI emits no OSC 133 marks (probed), so for
+# agent replies use prefix+O below. The cursor-up/end-of-line step trims
+# the next prompt's first character that the naive chain would grab.
+bind P copy-mode \; send -X previous-prompt -o \; send -X begin-selection \; send -X next-prompt \; send -X cursor-up \; send -X end-of-line \; send -X copy-pipe-and-cancel pbcopy \; display "copied: last command output"
+
+# prefix+O (agent Output; Y is tmux-yank's): copy Claude's latest reply
+# as original markdown from the session transcript — screen-independent,
+# so it works where OSC 133 can't. Shell alias: ccl (supports -n N).
+bind O run-shell "$HOME/.local/bin/claude-copy-last -c && tmux display 'copied: last Claude message' || tmux display 'no Claude message for this pane cwd'"
 
 bind h select-pane -L
 bind j select-pane -D

--- a/.zshrc
+++ b/.zshrc
@@ -537,6 +537,11 @@ if command -v glow &> /dev/null; then
     alias md='glow'
 fi
 
+# Copy Claude's latest reply (original markdown, from the session
+# transcript — screen-independent). ccl -n 2 reaches one message back;
+# pipes emit raw markdown: ccl | glow, ccl > notes.md
+alias ccl='claude-copy-last'
+
 # Search and replace TUI (scooter replaced serpl)
 if command -v scooter &> /dev/null; then
     alias sr='scooter'

--- a/README.md
+++ b/README.md
@@ -476,6 +476,14 @@ live Claude panes are identifiable in the status bar.
 - `claude-notify` (OSC 9/777) and OSC52 clipboard already bridge
   notifications and copy back to Ghostty.
 
+### Copying Claude's Last Reply
+
+`~/.local/bin/claude-copy-last` (alias `ccl`, tmux `prefix+O`) copies
+Claude's latest reply from the session transcript JSONL, so you get the
+*original* markdown instead of the wrapped screen text — identical in
+tmux, herdr, or bare Ghostty. `ccl -n 2` reaches a message further
+back; piping emits raw markdown (`ccl | glow`, `ccl > notes.md`).
+
 ## 🌐 Remote Development
 
 ### Shell TERM Handling
@@ -1190,6 +1198,7 @@ nvim --headless '+Lazy! sync' +qa
 ├── .local/
 │   └── bin/           # User scripts
 │       ├── battery-status        # Battery monitoring
+│       ├── claude-copy-last      # Copies Claude's last reply (ccl)
 │       ├── claude-name-session   # Auto-names Claude Code sessions
 │       ├── claude-notify         # OSC 9/777 desktop notifications
 │       ├── claude-statusline     # Rich Claude Code statusline

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -456,6 +456,14 @@ Claude Code 本身已內建跨專案的工作階段探索 — 關鍵在於替工
 - `claude-notify`(OSC 9/777)與 OSC52 剪貼簿已把通知與複製橋接回
   Ghostty。
 
+### 複製 Claude 的上一則回覆
+
+`~/.local/bin/claude-copy-last`(別名 `ccl`,tmux `prefix+O`)直接從
+工作階段的 transcript JSONL 取出 Claude 最新的回覆並複製到剪貼簿,拿到
+的是**原始 markdown**,而不是螢幕上折行後的文字 — 在 tmux、herdr 或
+純 Ghostty 裡行為完全相同。`ccl -n 2` 可往回撈一則;接管線時輸出原始
+markdown(`ccl | glow`、`ccl > notes.md`)。
+
 ## 遠端開發
 
 ### Shell TERM 處理
@@ -1160,6 +1168,7 @@ nvim --headless '+Lazy! sync' +qa
 ├── .local/
 │   └── bin/           # 使用者腳本
 │       ├── battery-status        # 電池監控
+│       ├── claude-copy-last      # 複製 Claude 上一則回覆(ccl)
 │       ├── claude-name-session   # 自動命名 Claude Code 工作階段
 │       ├── claude-notify         # OSC 9/777 桌面通知
 │       ├── claude-statusline     # Claude Code 豐富狀態列

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -71,16 +71,28 @@ columns, so shared muscle memory and divergences both stand out.
 | `prefix+alt+j` | — | New jj workspace (new tab) |
 | `prefix+1..9` | Switch to window N (default) | Switch to tab N (default) |
 | `prefix+[` | Copy mode, vi keys | Copy mode, vi keys (default) |
+| `prefix+P` | Copy previous command's output | — (FR drafted) |
+| `prefix+O` | Copy Claude's last reply (transcript) | — (FR drafted) |
 | `F12` | Toggle nested/outer tmux | — |
 
 Copy mode is the same in both tools: `prefix+[` to enter, then vim
 motions (`h/j/k/l`, `w/b/e`, `0/^/$`, `{`/`}`, `g/G`), `/`+`n/N` to
 search, `v` to start a selection (`V` whole line), `y` to copy and
 exit, `q` to leave without copying. tmux additionally has `C-v` for
-rectangle selection. For structured strings (paths, URLs, hashes)
+rectangle selection and `(` / `)` to jump backward / forward between
+shell prompt marks. For structured strings (paths, URLs, hashes)
 skip copy mode entirely: `prefix+F` (tmux thumbs) or `prefix+u`/
 `prefix+shift+u` (herdr termscope) hint-pick them in one keystroke,
 and Ghostty's `cmd+f` searches the scrollback directly.
+
+Copying a whole block comes in two flavours. `prefix+P` grabs the
+previous command's complete output by walking the OSC 133 prompt
+marks that Ghostty's zsh shell integration emits (they survive into
+tmux panes), so it covers shell commands only. Claude Code's TUI
+emits no OSC 133 marks at all, which is why `prefix+O` — and the
+`ccl` alias for `~/.local/bin/claude-copy-last` — skips the screen
+entirely and reads the session transcript JSONL instead, returning
+the original markdown rather than the rendered, wrapped text.
 
 Notes on divergences:
 
@@ -88,6 +100,8 @@ Notes on divergences:
 - `prefix+r` (lowercase) is tmux's legacy reload alias; herdr enters
   resize mode instead — an intentional divergence, not an alignment.
 - `prefix+R` (uppercase) is the aligned reload key in both tools.
+- `prefix+P` / `prefix+O` have no herdr equivalent yet; both are
+  drafted as upstream feature requests.
 - jj workspace removal is unbound on purpose (destructive action).
 
 ## Layer 3: Seamless navigation (bare ctrl+h/j/k/l)

--- a/docs/upgrade-watch.md
+++ b/docs/upgrade-watch.md
@@ -16,6 +16,7 @@ maintenance.
 | `lazygit config.yml` | lazygit | (6) | none needed |
 | `~/.local/bin/env` (uv artifact) | uv | (7) | suite `env` check |
 | bob data dir (PATH + maintenance) | bob (git dev) | (8) | suite nvim boot |
+| `~/.claude/projects/*.jsonl` | Claude Code | (9) | suite fixture test |
 
 ## Notes
 
@@ -56,3 +57,12 @@ maintenance.
    advancing — until neo-tree called an API the frozen nvim lacked.
    PATH and the maintenance proxy-chmod now target the new dir (old
    kept as fallback). The suite's headless nvim boot is the canary.
+9. **Claude Code transcripts** — `claude-copy-last` (alias `ccl`,
+   tmux `prefix+O`) reads the session transcript JSONL under
+   `~/.claude/projects/<slug>/`, filtering on `.type == "assistant"`
+   and `.isSidechain`, then pulling `.message.content[].type` and
+   `.text`. That is Claude Code's internal on-disk format with no
+   compatibility guarantee: a renamed field anywhere in it turns a
+   copy into silent nothing. The suite's fixture test
+   ("claude-copy-last extracts latest message from fixture") is the
+   canary — it fails the day the schema drifts.

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -314,6 +314,11 @@ if [ -f "$HOME/.config/starship.toml" ]; then
         run_test "Tmux copy mode pinned to vi keys" \
             "grep -q 'mode-keys vi' $HOME/.tmux.conf && \
              grep -q 'copy-mode-vi v send -X begin-selection' $HOME/.tmux.conf"
+        # Keyboard copy: prefix+P (last shell output via OSC 133 marks)
+        # and prefix+O (last Claude reply via claude-copy-last)
+        run_test "Tmux keyboard-copy bindings present" \
+            "grep -q 'previous-prompt -o' $HOME/.tmux.conf && \
+             grep -q 'claude-copy-last -c' $HOME/.tmux.conf"
     fi
     # ssh-terminfo (not ssh-env) keeps TERM intact on remotes — herdr's
     # terminal-notification detection over SSH depends on it
@@ -535,6 +540,34 @@ if [ -f "$HOME/daily-maintenance-lib.sh" ]; then
     run_test "herdr strand: herdr absent (empty before) -> silent" \
         "bash -c \"$UT_SRC ! dm_herdr_strand_detected '' 'herdr 2.0' '$HERDR_UT_DIR/live.sock'\""
     rm -rf "$HERDR_UT_DIR"
+fi
+
+# claude-copy-last: fixture-based extraction. The transcript JSONL is
+# Claude Code INTERNAL format with no compat guarantee (tracked in
+# docs/upgrade-watch.md) — if an upgrade renames .type/.isSidechain/
+# .message.content, these turn red the same day. Fixture exercises the
+# real selection rules: sidechain entries and tool-use-only entries are
+# skipped, -n reaches past them.
+if [ -x "$HOME/.local/bin/claude-copy-last" ] && command -v jq >/dev/null 2>&1; then
+    CCL_TMP=$(mktemp -d)
+    mkdir -p "$CCL_TMP/work"
+    CCL_SLUG=$(printf '%s' "$CCL_TMP/work" | sed 's/[^A-Za-z0-9]/-/g')
+    mkdir -p "$CCL_TMP/projects/$CCL_SLUG"
+    cat > "$CCL_TMP/projects/$CCL_SLUG/fixture.jsonl" <<'CCL_EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}
+{"type":"assistant","isSidechain":false,"message":{"content":[{"type":"text","text":"first reply"}]}}
+{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"text","text":"sidechain noise"}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"final answer"}]}}
+CCL_EOF
+    CCL_RUN="cd '$CCL_TMP/work' && CLAUDE_PROJECTS_DIR='$CCL_TMP/projects' '$HOME/.local/bin/claude-copy-last'"
+    run_test "claude-copy-last extracts latest message from fixture" \
+        "[ \"\$(bash -c \"$CCL_RUN\")\" = 'final answer' ]"
+    run_test "claude-copy-last -n 2 skips sidechain and tool-use entries" \
+        "[ \"\$(bash -c \"$CCL_RUN -n 2\")\" = 'first reply' ]"
+    run_test "claude-copy-last fails cleanly when history exhausted" \
+        "! bash -c \"$CCL_RUN -n 9\" 2>/dev/null"
+    rm -rf "$CCL_TMP"
 fi
 
 # gitleaks pre-commit engine: same invocation the yadm hook uses, against


### PR DESCRIPTION
Replaces mouse selection for the two copy operations that happen all day: grabbing a shell command's output, and grabbing Claude's last reply.

## Fact-check first (the frame was wrong)

The research round proposed copying agent messages via OSC 133 prompt boundaries. Empirical probes killed that frame:

- A pane running **only** `claude` (no shell) shows **zero** prompt marks — `previous-prompt` doesn't move (cursor 26→26→26). Claude's TUI doesn't emit OSC 133; only zsh does (Ghostty integration, verified to survive into tmux panes).
- The research's naive copy chain also grabbed one stray character of the next prompt — fixed with a `cursor-up`/`end-of-line` step (fixture-verified: copies exactly the output).
- Its "install termscope / tmux-thumbs" advice was redundant — both already installed (`prefix+u`/`U`, `prefix+F`).

## What shipped

| Key | What it copies |
|---|---|
| `prefix+P` (tmux) | Previous shell command's complete output, via OSC 133 marks. Shell commands only. |
| `prefix+O` / `ccl` | Claude's latest reply as **original markdown**, read from the session transcript JSONL — screen-independent, works in tmux/herdr/bare Ghostty. `ccl -n 2` reaches back; pipes emit raw markdown (`ccl \| glow`). |
| `(` / `)` in copy mode | Jump between shell prompts. |

`claude-copy-last` disambiguates sessions by pane cwd (slug + parent walk) so concurrent agents in other projects don't bleed in. Skips sidechain (subagent) and tool-use-only entries.

## Risk & canary

The transcript JSONL is Claude Code **internal** format with no compat guarantee — logged in `docs/upgrade-watch.md`; three suite fixture tests (latest / `-n 2` skip rules / clean exhaustion failure) turn red the day the schema drifts.

## Validation

- shellcheck clean; suite green (121 checks incl. 4 new); markdownlint clean
- Live-verified: tmux reloaded, both prefix bindings + `( )` present; script tested in piped, `-n`, `-c`, and error paths
- Docs: keybind contract rows, README (en+zh-TW), upgrade-watch entry; herdr-side equivalents added to the pending upstream FR draft