### PR TITLE
feat(herdr): bind prefix+shift+o to claude-copy-last — close the O gap

### DIFF
--- a/.config/herdr/config.toml##template
+++ b/.config/herdr/config.toml##template
@@ -66,6 +66,19 @@ command = "zsh"
 width = "80%"
 height = "70%"
 
+# Copy Claude's latest reply — same physical keystroke as tmux's
+# prefix+O (tmux "O" = shift+o; herdr spells the shift out). "shell"
+# type runs detached with the FOCUSED PANE's cwd (source-verified:
+# navigate.rs custom_command_env sets cwd = pane_cwd), so the script's
+# pane-cwd session disambiguation carries over. Silent on success —
+# just paste. A native copy_last_agent_message action is in the
+# upstream FR draft; this is the workaround until then.
+[[keys.command]]
+key = "prefix+shift+o"
+type = "shell"
+command = "$HOME/.local/bin/claude-copy-last -c"
+description = "copy last Claude message"
+
 # ── Plugin bindings ────────────────────────────────────────────────
 # vim-herdr-navigation: same bare ctrl+hjkl contract as the existing
 # tmux vim-tmux-navigator plugin — vim-aware, falls through to pane focus

--- a/.local/bin/claude-copy-last
+++ b/.local/bin/claude-copy-last
@@ -75,7 +75,13 @@ if [ -z "$proj" ]; then
     exit 1
 fi
 
-# Newest transcript = the active / most recent session for this project
+# Newest transcript = the active / most recent session for this project.
+# KNOWN LIMITATION (review 2026-08-06): two concurrent sessions in the
+# SAME project share one slug dir, and last-write-wins picks whichever
+# wrote most recently — not necessarily the pane you pressed the key
+# in. The proper fix is matching the pane's session id against the
+# filename (claude-name-session already reaches that id); accepted for
+# now since the newest transcript is almost always the one on screen.
 # shellcheck disable=SC2012  # slug dirs + uuid names, no odd characters
 transcript=$(ls -t "$proj"/*.jsonl | head -1)
 
@@ -92,13 +98,29 @@ msg=$(tail -n 5000 "$transcript" | jq -rs --argjson n "$n" '
 
 if [ -z "$msg" ]; then
     echo "claude-copy-last: no assistant message (n=$n) in ${transcript##*/}" >&2
+    # A long tool-heavy session can push text messages out of the tail
+    # window — say so instead of letting it read as "no messages exist"
+    if [ "$(wc -l < "$transcript")" -gt 5000 ]; then
+        echo "claude-copy-last: note: only the last 5000 lines were searched" >&2
+    fi
     exit 1
 fi
 
+# macOS today; wl-copy/xclip cover a future remote-Linux herdr server
+clip() {
+    if command -v pbcopy >/dev/null 2>&1; then pbcopy
+    elif command -v wl-copy >/dev/null 2>&1; then wl-copy
+    elif command -v xclip >/dev/null 2>&1; then xclip -selection clipboard
+    else
+        echo "claude-copy-last: no clipboard tool (pbcopy/wl-copy/xclip)" >&2
+        return 1
+    fi
+}
+
 if [ "$copy" = always ]; then
-    printf '%s' "$msg" | pbcopy
+    printf '%s' "$msg" | clip
 elif [ -t 1 ]; then
-    printf '%s' "$msg" | pbcopy
+    printf '%s' "$msg" | clip
     first_line=$(printf '%s' "$msg" | head -n 1)
     printf 'copied %s chars from %s\n' "${#msg}" "${transcript##*/}"
     printf '%.100s…\n' "$first_line"

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -72,7 +72,7 @@ columns, so shared muscle memory and divergences both stand out.
 | `prefix+1..9` | Switch to window N (default) | Switch to tab N (default) |
 | `prefix+[` | Copy mode, vi keys | Copy mode, vi keys (default) |
 | `prefix+P` | Copy previous command's output | — (FR drafted) |
-| `prefix+O` | Copy Claude's last reply (transcript) | — (FR drafted) |
+| `prefix+O` | Copy Claude's last reply (transcript) | Same (shell command) |
 | `F12` | Toggle nested/outer tmux | — |
 
 Copy mode is the same in both tools: `prefix+[` to enter, then vim
@@ -100,8 +100,14 @@ Notes on divergences:
 - `prefix+r` (lowercase) is tmux's legacy reload alias; herdr enters
   resize mode instead — an intentional divergence, not an alignment.
 - `prefix+R` (uppercase) is the aligned reload key in both tools.
-- `prefix+P` / `prefix+O` have no herdr equivalent yet; both are
-  drafted as upstream feature requests.
+- `prefix+P` has no herdr equivalent yet (copy mode lacks prompt
+  jumps; drafted as an upstream feature request). `prefix+O` works in
+  both: tmux binds `O`, herdr spells it `prefix+shift+o` — the same
+  physical keystroke — as a `type = "shell"` custom command that runs
+  `claude-copy-last -c` with the focused pane's cwd. herdr keybinds
+  are read at client attach, so after config changes reload the
+  server AND re-attach the client. A native
+  `copy_last_agent_message` action remains in the FR draft.
 - jj workspace removal is unbound on purpose (destructive action).
 
 ## Layer 3: Seamless navigation (bare ctrl+h/j/k/l)

--- a/docs/work-machine-checklist.md
+++ b/docs/work-machine-checklist.md
@@ -31,6 +31,14 @@ this repo — most common) or **fresh clone**. Update path first.
   ```
 
 - [ ] Post-pull migration (delta since mid-2026 versions):
+  - Keyboard copy (2026-08-06, PRs #76–#78): after this pull you have
+    `claude-copy-last` (`ccl`) — copies Claude's latest reply from the
+    session transcript to the clipboard; `ccl -n 2` reaches back. To
+    activate: open a new shell (alias), `tmux source ~/.tmux.conf`
+    (`prefix+P` = last shell output, `prefix+O` = last Claude reply,
+    vi copy mode with `v`/`C-v`/`(`/`)`), and if herdr is installed,
+    detach + re-attach the client (`prefix+shift+o`, keys are read at
+    attach). Uses `pbcopy` on macOS; jq required (Brewfile has it).
   - `yadm bootstrap` — idempotent; installs TPM/pay-respects/etc.
   - `brew bundle --file=~/Brewfile` selectively (`gitleaks` matters:
     the pre-commit hook uses it; it skips with a warning if absent)

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -320,6 +320,13 @@ if [ -f "$HOME/.config/starship.toml" ]; then
             "grep -q 'previous-prompt -o' $HOME/.tmux.conf && \
              grep -q 'claude-copy-last -c' $HOME/.tmux.conf"
     fi
+    # Keybind contract: herdr must carry the same copy-last-reply key
+    # (prefix+shift+o = tmux's prefix+O) in the TEMPLATE (source of
+    # truth — the generated config.toml is derived from it)
+    if [ -f "$HOME/.config/herdr/config.toml##template" ]; then
+        run_test "herdr copy-last-reply binding present in template" \
+            "grep -q 'claude-copy-last -c' '$HOME/.config/herdr/config.toml##template'"
+    fi
     # ssh-terminfo (not ssh-env) keeps TERM intact on remotes — herdr's
     # terminal-notification detection over SSH depends on it
     # (ssh-env is the wrong tool: it downgrades TERM to xterm-256color)
@@ -582,7 +589,8 @@ if command -v gitleaks >/dev/null 2>&1 && command -v git >/dev/null 2>&1; then
     GL_TMP=$(mktemp -d)
     GL_GIT="env -u GIT_DIR -u GIT_WORK_TREE git"
     $GL_GIT -C "$GL_TMP" init -q &&
-        $GL_GIT -C "$GL_TMP" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+        $GL_GIT -C "$GL_TMP" -c user.email=t@t -c user.name=t \
+            -c commit.gpgsign=false commit -q --allow-empty -m init
     printf 'aws_key = "%s%s"\n' "AKIA" "ZZZQK9X2M4P7L3TQ" > "$GL_TMP/leak.txt"
     $GL_GIT -C "$GL_TMP" add leak.txt
     run_test "gitleaks flags a staged canary secret" \


### PR DESCRIPTION
Fixes the gap you hit: `ctrl+a O` did nothing in herdr because `prefix+O` only existed in tmux.

## What & why it's safe

- New `[[keys.command]]` in the herdr config **template**: `prefix+shift+o` (same physical keystroke as tmux's `O`) → `type = "shell"` → `claude-copy-last -c`.
- **Source-verified before binding**: `spawn_custom_command` runs the user's shell `-lc`, detached, **with the focused pane's cwd** (`custom_command_env` sets `cwd = pane_cwd`) — so the script's pane-cwd session disambiguation carries over intact. `$HOME` expands at shell level.
- Silent on success by design (no popup); just paste afterwards.

## Tested

- `yadm alt` regenerated; `herdr server reload-config` → `status: applied`, `diagnostics: []`
- End-to-end with herdr's **exact spawn recipe** (`zsh -lc`, stdio nulled): exit 0, clipboard received the latest Claude reply — from a project root **and** from a subdirectory (parent-walk)
- Suite green (122 checks incl. new template guard); markdownlint clean

## Also in this PR

Suite hermeticity fix found while testing: the gitleaks fixture's init commit inherited the global `op-ssh-sign` config, so a **locked 1Password failed the test suite** from inside a throwaway fixture. Now passes `-c commit.gpgsign=false`.

## Notes for review

- Commit is **signed** (amended and force-pushed over SSH after 1Password came back; the earlier unsigned commit + one-shot HTTPS push was the locked-1Password workaround and has been replaced).
- herdr `[keys]` are **client-read at attach**: after merging, detach + re-attach the herdr client once. Then `ctrl+a` `shift+O` copies the last Claude reply; paste anywhere.
- No auto-merge on purpose — left for your review.