### PR TITLE
chore(gitignore): ignore machine-local overrides and backup copies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,20 @@
 # Claude Code local settings (machine-specific permissions)
 .claude/settings.local.json
 
+# Machine-local shell overrides. On a work machine this holds corp paths
+# and identity, so it must never be committed to this PUBLIC repo. Note
+# status.showUntrackedFiles=no means an unignored file here would be
+# INVISIBLE to `yadm status` while still stageable by `yadm add -A`.
+.zshrc.local
+.zshenv.local
+.daily-maintenance.local
+
+# Backup/snapshot copies of any of the above — same content, same risk
+*.bak
+*.bak-*
+*.backup
+*.orig
+
 .bin/assets/corona
 .config/vifm/vifminfo
 vim/plugged/


### PR DESCRIPTION
Machine-local override files were never ignored:

- `.zshrc.local`, `.zshenv.local`, `.daily-maintenance.local`
- `*.bak`, `*.bak-*`, `*.backup`, `*.orig`

On a work machine the first group holds corp paths and identity. Because
this repo sets `status.showUntrackedFiles = no`, an unignored file there is
**invisible to `yadm status`** yet still staged by `yadm add -A` — so the
normal review step never sees it before it reaches this public repo.

`.claude/settings.local.json` was already covered; its timestamped backups
were not, and two had been sitting untracked-but-stageable since 2026-08-04.

Verified: all six paths now report ignored; `.zshrc`, `.claude/settings.json`
and `.gitignore` remain tracked and visible. Full test suite green,
markdownlint clean.