### PR TITLE
fix(herdr): make prefix+shift+o (copy last Claude reply) work under --remote attach

### DIFF
--- a/.config/herdr/config.toml##template
+++ b/.config/herdr/config.toml##template
@@ -68,11 +68,18 @@ height = "70%"
 
 # Copy Claude's latest reply — same physical keystroke as tmux's
 # prefix+O (tmux "O" = shift+o; herdr spells the shift out). "shell"
-# type runs detached with the FOCUSED PANE's cwd (source-verified:
-# navigate.rs custom_command_env sets cwd = pane_cwd), so the script's
-# pane-cwd session disambiguation carries over. Silent on success —
-# just paste. A native copy_last_agent_message action is in the
-# upstream FR draft; this is the workaround until then.
+# type runs detached IN THE SERVER PROCESS with the FOCUSED PANE's cwd
+# (source-verified: navigate.rs custom_command_env sets cwd =
+# pane_cwd), so the script's pane-cwd session disambiguation carries
+# over, and the script delivers to the attached client's clipboard via
+# OSC 52 to the pane's pty (pbcopy alone would set the SERVER
+# clipboard). REMOTE ATTACH: this binding only fires with
+# `--remote-keybindings=server` — the server strips [[keys.command]]
+# from client-supplied keymaps (parse_client_keybindings clears
+# keys.command; deliberate policy, see docs/herdr-setup.md). Silent on
+# success — just paste; failures toast via `herdr notification show`.
+# A native copy_last_agent_message action is in the upstream FR draft;
+# this is the workaround until then.
 [[keys.command]]
 key = "prefix+shift+o"
 type = "shell"

--- a/.local/bin/claude-copy-last
+++ b/.local/bin/claude-copy-last
@@ -29,6 +29,26 @@ case ":$PATH:" in
   *) PATH="/opt/homebrew/bin:$PATH" ;;
 esac
 
+# herdr spawns [[keys.command]] shells in the SERVER process with the
+# daemon's (minimal) env — HERDR_BIN_PATH is injected there and beats
+# hoping `herdr` is on that PATH.
+herdr_bin="${HERDR_BIN_PATH:-herdr}"
+
+# Feedback for the detached -c path: spawn_custom_command nulls stdio,
+# so stderr goes nowhere — a herdr toast reaches the attached client
+# (local or --remote), unlike terminal-notifier which only ever reaches
+# the server's own screen. Toast only in -c mode; interactive has stderr.
+notify() {
+    if [ -n "${HERDR_ACTIVE_PANE_ID:-}" ]; then
+        "$herdr_bin" notification show "claude-copy-last" --body "$1" \
+            >/dev/null 2>&1 && return
+    fi
+    if command -v terminal-notifier >/dev/null 2>&1; then
+        terminal-notifier -title claude-copy-last -message "$1" \
+            >/dev/null 2>&1 || true
+    fi
+}
+
 n=1
 copy=auto
 while getopts "n:ch" opt; do
@@ -72,6 +92,7 @@ done
 
 if [ -z "$proj" ]; then
     echo "claude-copy-last: no Claude transcripts for $PWD (or parents)" >&2
+    [ "$copy" = always ] && notify "no Claude transcripts for $PWD (or parents)"
     exit 1
 fi
 
@@ -103,6 +124,7 @@ if [ -z "$msg" ]; then
     if [ "$(wc -l < "$transcript")" -gt 5000 ]; then
         echo "claude-copy-last: note: only the last 5000 lines were searched" >&2
     fi
+    [ "$copy" = always ] && notify "no assistant message (n=$n) in ${transcript##*/}"
     exit 1
 fi
 
@@ -117,10 +139,64 @@ clip() {
     fi
 }
 
+# herdr drops clipboard writes over 192 KiB decoded SILENTLY (ghostty
+# MAX_CLIPBOARD_BYTES); guard at 190 KiB with margin. Computed once so
+# the two OSC 52 branches below can't drift apart.
+osc52_cap=194560
+msg_bytes=$(printf '%s' "$msg" | wc -c | tr -d ' ')
+
+osc52_seq() {
+    printf '\033]52;c;%s\a' "$(printf '%s' "$msg" | base64 | tr -d '\n')"
+}
+
+# herdr custom commands run in the SERVER process, so clip() above only
+# sets the SERVER's clipboard — invisible under `herdr --remote`.
+# Writing OSC 52 to the pane's pty enters herdr's own clipboard
+# pipeline (pane OSC 52 → ClipboardWrite → forwarded to the FOREGROUND
+# attached client, which sets its native clipboard).
+osc52_to_pane() {
+    [ -n "${HERDR_ACTIVE_PANE_ID:-}" ] || return 0
+    local info tty pid
+    if [ "$msg_bytes" -gt "$osc52_cap" ]; then
+        notify "message too large for remote clipboard ($msg_bytes bytes) — copied on the server only"
+        return 0
+    fi
+    info=$("$herdr_bin" pane process-info --pane "$HERDR_ACTIVE_PANE_ID" 2>/dev/null) || info=""
+    tty=$(printf '%s' "$info" | jq -r '.result.process_info.tty // empty' 2>/dev/null) || tty=""
+    if [ -z "$tty" ]; then
+        # macOS process-info omits tty (observed 0.8.0) — resolve via ps
+        pid=$(printf '%s' "$info" | jq -r '.result.process_info.shell_pid // .result.process_info.foreground_process_group_id // empty' 2>/dev/null) || pid=""
+        if [ -n "$pid" ]; then
+            tty=$(/bin/ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ') || tty=""
+        fi
+        case "$tty" in '' | '??' | '-') tty="" ;; esac
+    fi
+    if [ -z "$tty" ]; then
+        notify "pane tty not resolvable — copied on the server only"
+        return 0
+    fi
+    case "$tty" in /*) ;; *) tty="/dev/$tty" ;; esac
+    if [ -w "$tty" ]; then
+        osc52_seq > "$tty" ||
+            notify "OSC 52 write to $tty failed — copied on the server only"
+    else
+        notify "pane tty $tty not writable — copied on the server only"
+    fi
+}
+
 if [ "$copy" = always ]; then
-    printf '%s' "$msg" | clip
+    # clip failure must not gate OSC 52 (stdio is nulled — toast it):
+    # on a clipboard-tool-less server the pane delivery still works
+    printf '%s' "$msg" | clip || notify "server clipboard tool failed — pane OSC 52 only"
+    osc52_to_pane
 elif [ -t 1 ]; then
     printf '%s' "$msg" | clip
+    # Also OSC 52 through the controlling terminal: reaches the LOCAL
+    # clipboard when this shell is remote (ssh, herdr --remote pane) —
+    # harmless duplicate of clip() when local. Same cap guard.
+    if [ "$msg_bytes" -le "$osc52_cap" ]; then
+        osc52_seq > /dev/tty || true
+    fi
     first_line=$(printf '%s' "$msg" | head -n 1)
     printf 'copied %s chars from %s\n' "${#msg}" "${transcript##*/}"
     printf '%.100s…\n' "$first_line"

--- a/.local/bin/claude-copy-last
+++ b/.local/bin/claude-copy-last
@@ -96,15 +96,33 @@ if [ -z "$proj" ]; then
     exit 1
 fi
 
-# Newest transcript = the active / most recent session for this project.
-# KNOWN LIMITATION (review 2026-08-06): two concurrent sessions in the
-# SAME project share one slug dir, and last-write-wins picks whichever
-# wrote most recently — not necessarily the pane you pressed the key
-# in. The proper fix is matching the pane's session id against the
-# filename (claude-name-session already reaches that id); accepted for
-# now since the newest transcript is almost always the one on screen.
-# shellcheck disable=SC2012  # slug dirs + uuid names, no odd characters
-transcript=$(ls -t "$proj"/*.jsonl | head -1)
+# Which transcript belongs to the pane you pressed the key in?
+# Concurrent agents in one directory share a slug dir, so "newest file"
+# copies whichever session wrote last — with two Claude panes both in
+# $HOME, pressing in one reliably pasted the other's reply.
+# herdr answers this directly: it tracks each pane's Claude session id
+# and transcripts are named <session-id>.jsonl. Ask it first, fall back
+# to mtime for plain shells, tmux, or panes whose agent never reported
+# an identity (herdr leaves agent_session unset there).
+transcript=""
+if [ -n "${HERDR_ACTIVE_PANE_ID:-}" ]; then
+    sid=$("$herdr_bin" pane get "$HERDR_ACTIVE_PANE_ID" 2>/dev/null |
+        jq -r '.result.pane.agent_session.value // empty' 2>/dev/null) || sid=""
+    if [ -n "$sid" ]; then
+        if [ -f "$proj/$sid.jsonl" ]; then
+            transcript="$proj/$sid.jsonl"
+        else
+            # cwd walk landed on a different project dir than the one
+            # claude was launched from — the id is authoritative, so
+            # take it wherever it lives
+            transcript=$(find "$projects_root" -maxdepth 2 -name "$sid.jsonl" -print -quit 2>/dev/null)
+        fi
+    fi
+fi
+if [ -z "$transcript" ]; then
+    # shellcheck disable=SC2012  # slug dirs + uuid names, no odd characters
+    transcript=$(ls -t "$proj"/*.jsonl | head -1)
+fi
 
 # Sidechain entries are subagent traffic, not the conversation. One turn
 # can hold several text blocks (status notes between tool calls); each

--- a/.zshrc
+++ b/.zshrc
@@ -557,6 +557,33 @@ fi
 # chord instead of vim-herdr-navigation moving pane focus
 if command -v herdr &> /dev/null; then
     export HERDR_NAV_PASSTHROUGH_RE='^lazygit$'
+
+    # hbox — attach to a remote herdr server (works Mac or Linux on both
+    # ends; nothing here is host-specific).
+    #
+    # --remote-keybindings=server is LOAD-BEARING, not a preference. The
+    # default is local, which makes the SERVER strip every custom
+    # command out of the client's keymap (deliberate upstream: a client
+    # config must not inject shell onto the server host). Every custom
+    # binding — prefix+shift+o (claude-copy-last), sessionizer,
+    # termscope — then does nothing at all, with no error. Keybindings
+    # are read ONCE at attach, so a client already running cannot be
+    # fixed; it has to reattach. This cost a full debugging session.
+    #
+    # --handoff: when the attach replaces a version-mismatched remote
+    # server, live panes are handed over instead of killed.
+    #
+    # Host comes from $HERDR_REMOTE_HOST, set per machine in the
+    # UNTRACKED ~/.zshrc.local (this repo is public — no hosts in it),
+    # or passed directly: hbox user@otherbox
+    hbox() {
+        local target="${1:-$HERDR_REMOTE_HOST}"
+        if [[ -z "$target" ]]; then
+            print -u2 "hbox: set HERDR_REMOTE_HOST in ~/.zshrc.local, or pass user@host"
+            return 2
+        fi
+        herdr --remote="$target" --remote-keybindings=server --handoff
+    }
 fi
 
 # File management (yazi with cd-on-exit wrapper)

--- a/README.md
+++ b/README.md
@@ -483,6 +483,10 @@ Claude's latest reply from the session transcript JSONL, so you get the
 *original* markdown instead of the wrapped screen text — identical in
 tmux, herdr, or bare Ghostty. `ccl -n 2` reaches a message further
 back; piping emits raw markdown (`ccl | glow`, `ccl > notes.md`).
+Inside herdr it copies the transcript of the pane you pressed in, asked
+for by session id — several agents sharing a directory share a
+transcript folder, so picking the most recently written file would
+paste the neighbouring pane's reply.
 
 ## 🌐 Remote Development
 
@@ -655,6 +659,26 @@ two-week trial for Claude Code sessions only — tmux stays primary.
 Config lives in `~/.config/herdr/config.toml` (ctrl+a prefix,
 tmux-mirrored keys, Catppuccin); plugins are machine-local and
 SHA-pinned.
+
+Connect to a remote herdr server with the `hbox` helper — never plain
+`herdr --remote`:
+
+```bash
+hbox                  # uses $HERDR_REMOTE_HOST from ~/.zshrc.local
+hbox user@otherbox    # one-off target
+```
+
+It bakes in `--remote-keybindings=server`, which is load-bearing rather
+than cosmetic: the default (`local`) makes the server strip every
+custom command out of the client's keymap, so `prefix+shift+O` and the
+plugin bindings do nothing at all, with no error. Keybindings are read
+once at attach, so a client already running cannot be fixed — it has to
+reattach. Set the host per machine in the untracked `~/.zshrc.local`
+(`export HERDR_REMOTE_HOST='user@host'`), since this repo is public.
+
+One more rule for clipboard copies: **only one client may be attached**.
+herdr delivers a copy to the foreground client alone, so a forgotten
+`herdr` left running on the server host silently swallows every copy.
 
 Trial notes, plugin install commands, and known limits:
 [docs/herdr.md](docs/herdr.md). Full dual-machine setup (work laptop /

--- a/docs/herdr-setup.md
+++ b/docs/herdr-setup.md
@@ -98,15 +98,32 @@ Practical consequences:
   `--remote-keybindings` defaults to `local`: the client's `[keys]`
   always wins. Override with `--remote-keybindings=server` to use
   the remote's `[keys]` instead.
+- **Custom commands NEVER fire from a client-supplied keymap**
+  (source-verified 0.8.0): the server strips every `[[keys.command]]`
+  when parsing client keybindings (`parse_client_keybindings` runs
+  `config.keys.command.clear()`; a unit test asserts it — deliberate
+  policy so a client config can't inject shell onto the server host).
+  So bindings like `prefix+shift+o` (claude-copy-last) are dead under
+  a default `--remote` attach no matter which machine's config has
+  them — attach with `--remote-keybindings=server` (harmless here:
+  yadm ships the same config everywhere). When they do fire, the
+  shell spawns IN THE SERVER PROCESS with stdio null'd: `pbcopy` sets
+  the server's clipboard, stderr goes nowhere. `claude-copy-last`
+  therefore writes OSC 52 to the pane's pty (herdr forwards it to the
+  FOREGROUND attached client only — a second client sees nothing) and
+  toasts failures via `herdr notification show`. herdr silently drops
+  clipboard writes over 192 KiB decoded (`MAX_CLIPBOARD_BYTES`); the
+  script guards at 190 KiB and toasts instead.
 - **A locally-bound plugin key goes silent if the remote lacks the
   plugin.** Plugin actions execute server-side (e.g. `prefix+e` →
   reviewr), so every plugin must be installed on BOTH ends, pinned
   to the SAME `--ref` SHAs — mirror the block in Plugins below onto
   the remote machine.
-- **Toast delivery changes need a client re-attach, not a reload.**
-  `[ui.toast]` is read once at attach; `server reload-config` can't
-  push it to an already-attached client. `[ui.sound]` is the only
-  UI class that hot-reloads.
+- **Client-side config is attach-time, full stop.** Everything the
+  client reads (`[keys]`, `[ui.toast]`, `[remote]`) is read once at
+  attach; `server reload-config` only covers the server-side half.
+  `[ui.sound]` is the lone exception that hot-reloads. After changing
+  any client-side setting, detach and reattach every client.
 
 ## Plugins (each machine, SHA-pinned)
 
@@ -214,11 +231,12 @@ Mid-session `/rename` syncs on the next resume (no hook event exists).
 ## Daily entrypoints
 
 - Local: run `herdr` in a Ghostty tab (auto-starts the server).
-- Remote: `herdr --remote user@host`. **Verified from CLI help**:
-  `--remote-keybindings local` is the default — your local muscle
-  memory follows you. herdr's generated SSH config includes
-  `~/.ssh/config` first, so ProxyJump/ControlMaster/1Password agent
-  settings all apply.
+- Remote: `herdr --remote user@host --remote-keybindings=server`.
+  The `server` override is required for `[[keys.command]]` bindings
+  (stripped from client keymaps — see above) and costs nothing on
+  muscle memory since yadm ships identical configs. herdr's generated
+  SSH config includes `~/.ssh/config` first, so
+  ProxyJump/ControlMaster/1Password agent settings all apply.
 - The client does NOT auto-reconnect after a network drop (it exits
   with a reattach hint). A retry wrapper for `.zshrc`, **⚠ verify
   first** that a deliberate `prefix+q` detach exits 0 (detach once,
@@ -228,8 +246,10 @@ Mid-session `/rename` syncs on the next resume (no hook event exists).
 hbox() {
   while true; do
     # --handoff: if the attach replaces the remote server (version
-    # sync), live panes are handed over instead of killed
-    herdr --remote user@box --handoff "$@" && break
+    # sync), live panes are handed over instead of killed;
+    # server keybindings: [[keys.command]] is stripped from client
+    # keymaps, so custom commands need the server's own keymap
+    herdr --remote user@box --handoff --remote-keybindings=server "$@" && break
     print "connection lost — retrying in 2s (Ctrl-C to stop)"
     sleep 2
   done

--- a/docs/herdr-setup.md
+++ b/docs/herdr-setup.md
@@ -109,11 +109,37 @@ Practical consequences:
   yadm ships the same config everywhere). When they do fire, the
   shell spawns IN THE SERVER PROCESS with stdio null'd: `pbcopy` sets
   the server's clipboard, stderr goes nowhere. `claude-copy-last`
-  therefore writes OSC 52 to the pane's pty (herdr forwards it to the
-  FOREGROUND attached client only — a second client sees nothing) and
-  toasts failures via `herdr notification show`. herdr silently drops
-  clipboard writes over 192 KiB decoded (`MAX_CLIPBOARD_BYTES`); the
-  script guards at 190 KiB and toasts instead.
+  therefore writes OSC 52 to the pane's pty and toasts failures via
+  `herdr notification show`. herdr silently drops clipboard writes over
+  192 KiB decoded (`MAX_CLIPBOARD_BYTES`); the script guards at 190 KiB
+  and toasts instead.
+- **A stale second client silently steals every clipboard copy**
+  (**verified the hard way, 2026-08-08 — cost most of a day**).
+  `ClipboardWrite` goes to `foreground_client_id` ONLY —
+  `send_to_foreground_client`, deliberate upstream ("clipboard writes
+  are client-local side effects... not broadcast"). So a forgotten
+  `herdr` left attached on the SERVER host keeps foreground and every
+  copy lands on the server's pasteboard while your `--remote` client
+  gets nothing. There is no error, no toast, no log line — the copy
+  succeeds, just onto the wrong machine.
+  Symptom: `prefix+shift+o` "does nothing", but `pbpaste` ON THE SERVER
+  shows the text. Diagnosis, since no CLI exposes the client list:
+
+  ```bash
+  grep -oE 'client (connected|disconnected) client_id=[0-9]+' \
+    ~/.config/herdr/herdr-server.log |
+    awk '{split($3,a,"="); if($2=="connected") s[a[2]]=1; else delete s[a[2]]}
+         END {for (k in s) printf "%s ", k; print ""}'
+  ```
+
+  More than one id = the bug is live. Fix: `kill` the stale client's
+  process (a detach — the server and every pane survive);
+  `promote_latest_remaining_client` hands foreground back. Confirm with
+  a sentinel: set the server clipboard, write one OSC 52 to a pane tty,
+  and check that the server's clipboard is UNCHANGED — that proves the
+  write went to the remote client instead. Runtime `foreground_client_id`
+  is otherwise only visible via `HERDR_LOG=herdr=debug`, which needs a
+  server restart and therefore kills every pane.
 - **A locally-bound plugin key goes silent if the remote lacks the
   plugin.** Plugin actions execute server-side (e.g. `prefix+e` →
   reviewr), so every plugin must be installed on BOTH ends, pinned

--- a/docs/herdr-setup.md
+++ b/docs/herdr-setup.md
@@ -254,14 +254,54 @@ the equivalent of the old tmux window rename. New sessions get the
 `project/branch` default; resumed sessions mirror their real title.
 Mid-session `/rename` syncs on the next resume (no hook event exists).
 
+## Remote attach checklist (same on macOS and Linux)
+
+Nothing below is OS-specific — it is the same on a Mac mini, a Linux
+box, or a work server. Use this when setting up a new pair.
+
+**Server** (the box being attached to): herdr installed at the SAME
+version as the client; every plugin installed that any key binds to,
+since plugin actions execute server-side; `config.toml` generated from
+the dotfiles (`yadm alt`) — under the flag below it is the server's
+`[keys]` that actually runs.
+
+**Client** (the laptop you sit at): herdr installed, same version;
+attach with `--remote-keybindings=server`; and be the ONLY attached
+client.
+
+Two settings are load-bearing and neither lives in `config.toml`:
+
+1. **`--remote-keybindings=server` on every attach.** There is no
+   config key for it (`[remote]` holds only `manage_ssh_config`), and
+   the internal `HERDR_REMOTE_KEYBINDINGS` env var must not be set by
+   hand — the client also uses its presence to decide whether it is a
+   remote process. Use the tracked `hbox` helper in `.zshrc`, which
+   bakes in the flag and reads the host from `$HERDR_REMOTE_HOST` in
+   the untracked `~/.zshrc.local` (this repo is public, so no hosts in
+   it):
+
+   ```bash
+   # ~/.zshrc.local on each client machine
+   export HERDR_REMOTE_HOST='user@work-server'
+   ```
+
+   Then `hbox` attaches, or `hbox user@otherbox` for a one-off.
+2. **Exactly one attached client**, or clipboard copies go to whichever
+   client holds foreground (see the stale-client bullet above).
+
+Clipboard, per OS: the copy is delivered to the CLIENT, so the client's
+OS is what matters and both are handled natively. On the SERVER the
+script also does a local copy as a convenience — `pbcopy` on macOS,
+`wl-copy`/`xclip` on Linux — and when none exists (a headless Linux
+server) that step is skipped without blocking the OSC 52 delivery that
+actually reaches you.
+
 ## Daily entrypoints
 
 - Local: run `herdr` in a Ghostty tab (auto-starts the server).
-- Remote: `herdr --remote user@host --remote-keybindings=server`.
-  The `server` override is required for `[[keys.command]]` bindings
-  (stripped from client keymaps — see above) and costs nothing on
-  muscle memory since yadm ships identical configs. herdr's generated
-  SSH config includes `~/.ssh/config` first, so
+- Remote: `hbox` (see the checklist above), which expands to
+  `herdr --remote=<host> --remote-keybindings=server --handoff`.
+  herdr's generated SSH config includes `~/.ssh/config` first, so
   ProxyJump/ControlMaster/1Password agent settings all apply.
 - The client does NOT auto-reconnect after a network drop (it exits
   with a reattach hint). A retry wrapper for `.zshrc`, **⚠ verify

--- a/docs/upgrade-watch.md
+++ b/docs/upgrade-watch.md
@@ -76,3 +76,9 @@ maintenance.
    macOS so the script falls back to `/bin/ps -o tty=`. If an
    upgrade changes any of these, the keybinding goes dark or the
    toast fallback stops firing.
+   It also reads `herdr pane get <id>` →
+   `.result.pane.agent_session.value` to select the transcript
+   belonging to the pane you pressed in. Renaming that field only
+   degrades to the old newest-file guess, which is wrong whenever two
+   agents share a directory — silently pasting the other pane's
+   reply. The suite asserts session-id selection beats mtime.

--- a/docs/upgrade-watch.md
+++ b/docs/upgrade-watch.md
@@ -66,3 +66,13 @@ maintenance.
    copy into silent nothing. The suite's fixture test
    ("claude-copy-last extracts latest message from fixture") is the
    canary — it fails the day the schema drifts.
+   The herdr delivery path (`-c` from `prefix+shift+o`) additionally
+   pins three herdr internals (all verified 0.8.0, watched by the
+   suite's stub-herdr OSC 52 tests): custom commands are stripped
+   from client keymaps (`parse_client_keybindings` —
+   `--remote-keybindings=server` is load-bearing), clipboard writes
+   over 192 KiB decoded are silently dropped (`MAX_CLIPBOARD_BYTES`,
+   script guards at 190 KiB), and `pane process-info` omits `tty` on
+   macOS so the script falls back to `/bin/ps -o tty=`. If an
+   upgrade changes any of these, the keybinding goes dark or the
+   toast fallback stops firing.

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -574,6 +574,55 @@ CCL_EOF
         "[ \"\$(bash -c \"$CCL_RUN -n 2\")\" = 'first reply' ]"
     run_test "claude-copy-last fails cleanly when history exhausted" \
         "! bash -c \"$CCL_RUN -n 9\" 2>/dev/null"
+
+    # herdr keybinding path (-c): custom commands spawn detached in the
+    # SERVER process with stdio null'd, so clipboard delivery is OSC 52
+    # written to the pane's pty (herdr forwards it to the attached
+    # client) and failures surface as herdr toasts. Stub herdr captures
+    # both; stub pbcopy keeps the suite off the real clipboard.
+    mkdir -p "$CCL_TMP/bin"
+    cat > "$CCL_TMP/bin/herdr" <<CCL_HERDR
+#!/usr/bin/env bash
+case "\$1 \$2" in
+    'pane process-info')
+        : > "$CCL_TMP/tty-capture"   # a real pane tty always exists
+        printf '{"result":{"process_info":{"tty":"%s"}}}' "$CCL_TMP/tty-capture" ;;
+    'notification show')
+        shift 2; printf '%s\n' "\$*" >> "$CCL_TMP/notify-log" ;;
+esac
+CCL_HERDR
+    chmod +x "$CCL_TMP/bin/herdr"
+    printf '#!/bin/sh\ncat > /dev/null\n' > "$CCL_TMP/bin/pbcopy"
+    chmod +x "$CCL_TMP/bin/pbcopy"
+    # Fixed PATH: the ambient one may contain spaces (Application Support)
+    # which cannot survive unquoted expansion inside the inner bash -c
+    CCL_ENV="PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/projects' HERDR_ACTIVE_PANE_ID=w1:p1 HERDR_BIN_PATH='$CCL_TMP/bin/herdr'"
+    CCL_B64=$(printf '%s' 'final answer' | base64 | tr -d '\n')
+    run_test "claude-copy-last -c writes OSC 52 to the herdr pane tty" \
+        "bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
+         [ \"\$(cat '$CCL_TMP/tty-capture' 2>/dev/null)\" = \"\$(printf '\\033]52;c;%s\\a' '$CCL_B64')\" ]"
+
+    # herdr silently DROPS clipboard writes over 192 KiB decoded
+    # (ghostty MAX_CLIPBOARD_BYTES) — oversize must skip OSC 52 and
+    # toast instead of vanishing.
+    mkdir -p "$CCL_TMP/big"
+    CCL_BIG_SLUG=$(printf '%s' "$CCL_TMP/big" | sed 's/[^A-Za-z0-9]/-/g')
+    mkdir -p "$CCL_TMP/projects/$CCL_BIG_SLUG"
+    head -c 200000 /dev/zero | tr '\0' 'a' |
+        jq -Rc '{type:"assistant",message:{content:[{type:"text",text:.}]}}' \
+        > "$CCL_TMP/projects/$CCL_BIG_SLUG/fixture.jsonl"
+    run_test "claude-copy-last -c toasts instead of oversize OSC 52" \
+        "rm -f '$CCL_TMP/tty-capture' '$CCL_TMP/notify-log' &&
+         bash -c \"cd '$CCL_TMP/big' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
+         [ ! -e '$CCL_TMP/tty-capture' ] && grep -q 'too large' '$CCL_TMP/notify-log'"
+
+    # Failure in -c mode must toast, not exit silently — stdio is
+    # null'd, so stderr goes nowhere.
+    mkdir -p "$CCL_TMP/empty-projects" "$CCL_TMP/nowhere"
+    run_test "claude-copy-last -c toasts when no transcript exists" \
+        "rm -f '$CCL_TMP/notify-log' &&
+         ! bash -c \"cd '$CCL_TMP/nowhere' && PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/empty-projects' HERDR_ACTIVE_PANE_ID=w1:p1 HERDR_BIN_PATH='$CCL_TMP/bin/herdr' '$HOME/.local/bin/claude-copy-last' -c\" 2>/dev/null &&
+         grep -q 'no Claude transcripts' '$CCL_TMP/notify-log'"
     rm -rf "$CCL_TMP"
 fi
 

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -602,6 +602,42 @@ CCL_HERDR
         "bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
          [ \"\$(cat '$CCL_TMP/tty-capture' 2>/dev/null)\" = \"\$(printf '\\033]52;c;%s\\a' '$CCL_B64')\" ]"
 
+    # Concurrent agents in ONE project dir: picking the newest file by
+    # mtime copies whichever session wrote last, not the pane you
+    # pressed in — observed live with two Claude panes both in $HOME.
+    # herdr knows each pane's Claude session id and transcripts are
+    # named <session-id>.jsonl, so the id must win over mtime. Fixture
+    # makes the OTHER session newer, so mtime-selection fails this.
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"MY PANE"}]}}\n' \
+        > "$CCL_TMP/projects/$CCL_SLUG/11111111-1111-1111-1111-111111111111.jsonl"
+    sleep 1
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"OTHER PANE"}]}}\n' \
+        > "$CCL_TMP/projects/$CCL_SLUG/22222222-2222-2222-2222-222222222222.jsonl"
+    # Stub reports a pane session only when the fixture asks for one, so
+    # the later tests still exercise the mtime path.
+    cat > "$CCL_TMP/bin/herdr" <<CCL_HERDR2
+#!/usr/bin/env bash
+case "\$1 \$2" in
+    'pane get')
+        sid=\$(cat "$CCL_TMP/stub-session" 2>/dev/null)
+        [ -n "\$sid" ] || exit 0
+        printf '{"result":{"pane":{"agent_session":{"value":"%s"}}}}' "\$sid" ;;
+    'pane process-info')
+        : > "$CCL_TMP/tty-capture"
+        printf '{"result":{"process_info":{"tty":"%s"}}}' "$CCL_TMP/tty-capture" ;;
+    'notification show')
+        shift 2; printf '%s\n' "\$*" >> "$CCL_TMP/notify-log" ;;
+esac
+CCL_HERDR2
+    chmod +x "$CCL_TMP/bin/herdr"
+    printf '11111111-1111-1111-1111-111111111111' > "$CCL_TMP/stub-session"
+    run_test "claude-copy-last picks the pane's own session, not newest file" \
+        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'MY PANE' ]"
+    rm -f "$CCL_TMP/stub-session"
+    # Without a pane (plain shell / tmux) it must still fall back to mtime
+    run_test "claude-copy-last falls back to newest file without a pane id" \
+        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/projects' '$HOME/.local/bin/claude-copy-last'\")\" = 'OTHER PANE' ]"
+
     # herdr silently DROPS clipboard writes over 192 KiB decoded
     # (ghostty MAX_CLIPBOARD_BYTES) — oversize must skip OSC 52 and
     # toast instead of vanishing.


### PR DESCRIPTION
## Problem

The `prefix+shift+o` → `claude-copy-last -c` binding (#78) never fires under `herdr --remote`. Source-verified root cause (herdrdev/herdr @ 6f31149, matches installed 0.8.0):

- With the default `--remote-keybindings local`, the client ships its `[keys]` TOML to the server, and `parse_client_keybindings` (`src/server/client_transport.rs`) runs `config.keys.command.clear()` — every `[[keys.command]]` is deliberately stripped (a client config must not inject shell onto the server host; a unit test asserts it). Custom commands can never fire from a default remote attach, regardless of which machine's config defines them.
- Latent second bug: custom commands spawn in the SERVER process with stdio nulled (`spawn_custom_command`), so `pbcopy` set the server's clipboard — invisible at the remote client — and all script failures were silent.

## Fix

- Attach with `--remote-keybindings=server` (docs + hbox sample updated); zero muscle-memory cost since yadm ships identical configs.
- `claude-copy-last` now writes OSC 52 to the pane's pty — herdr's own pipeline forwards it to the foreground attached client's native clipboard (works local and remote). Guards herdr's silent 192 KiB clipboard cap at 190 KiB; resolves the pane tty via `pane process-info` with a `/bin/ps` fallback (`tty` is omitted on macOS); every `-c` failure path now toasts via `herdr notification show`. Interactive use gains the same OSC 52 via `/dev/tty` for ssh sessions.

## Tests

- 3 new stub-herdr suite tests: OSC 52 framing to the pane tty, oversize→toast-not-write, no-transcript→toast. Full suite 120/120, markdownlint clean.
- `docs/upgrade-watch.md` pins the three herdr internals this leans on (keymap strip, 192 KiB cap, tty-null-on-macOS).

Reviewed in a two-agent loop (plan + implementation round); both reviewer notes (clip-failure ordering, hoisted size guard) applied.