### PR TITLE
ci: close two false-pass gaps in secret scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # REQUIRED by both secret scanners below. checkout defaults to
+          # fetch-depth 1, which silently reduces a "full history" scan
+          # to a single commit while still reporting success — the same
+          # false-pass class as running gitleaks outside a repo (it says
+          # "0 commits scanned ... no leaks found"). Cheap here: the repo
+          # is ~1.6 MB over ~300 commits, scanned in well under a second.
+          fetch-depth: 0
 
       # Trivy stays advisory: filesystem CVE scanning is noisy for a
       # dotfiles repo. Pinned to a release SHA (was @master — a mutable
@@ -206,6 +213,21 @@ jobs:
         with:
           path: ./
           extra_args: --results=verified
+
+      # Second, complementary net. --results=verified above means
+      # TruffleHog only fails on credentials it could confirm LIVE
+      # against the provider: a private key block, a revoked-but-real
+      # token, a password, or any provider it cannot verify all pass it
+      # silently. gitleaks is regex/entropy based and catches those.
+      # It is also the same engine the yadm pre_commit hook runs, and
+      # that hook is bypassable (--no-verify, or a raw GIT_DIR commit),
+      # so CI holds the authoritative copy of the gate. go install is
+      # the pattern already used for actionlint (verified through the
+      # Go checksum database); ubuntu-latest ships Go preinstalled.
+      - name: Check for secrets — gitleaks (blocking, full history)
+        run: |
+          go install github.com/zricethezav/gitleaks/v8@v8.30.1
+          "$(go env GOPATH)/bin/gitleaks" git --no-banner --redact .
 
   macos-integration:
     name: macOS Integration + Test Suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ main, master ]
   workflow_dispatch:
+  # TruffleHog scans a base..head DIFF on push/PR events and the FULL
+  # history only on workflow_dispatch/schedule (see security-scan). This
+  # weekly run is what makes its verified-credential scan eventually
+  # cover every commit, including anything merged before it was added.
+  schedule:
+    - cron: '17 4 * * 1'
 
 # Least-privilege GITHUB_TOKEN: nothing in this pipeline writes to the repo
 permissions:
@@ -203,15 +209,25 @@ jobs:
           output: 'trivy-results.sarif'
         continue-on-error: true
 
-      # BLOCKING secret scan over the FULL git history (not a base..head
-      # diff — the old diff mode failed with base==head on master pushes,
-      # which is why it was continue-on-error, i.e. decorative).
-      # --results=verified: only credentials that TruffleHog actively
-      # confirmed against the provider fail the build (no regex noise).
+      # BLOCKING, but scoped to a DIFF, not full history — verified by
+      # reading action.yml at the pinned SHA: with only `path` set it
+      # derives BASE/HEAD from the event (push -> before..after,
+      # pull_request -> base.sha..head.sha) and scans everything only on
+      # workflow_dispatch/schedule. That is why this job also carries a
+      # schedule trigger, and why gitleaks below is the true
+      # full-history net. fetch-depth: 0 stays REQUIRED either way —
+      # those base shas cannot resolve in a depth-1 clone.
+      # --results=verified: only credentials TruffleHog confirmed live
+      # against the provider fail the build (no regex noise).
+      # version: pins the scanner itself. The action SHA does not — it
+      # runs `docker run ghcr.io/trufflesecurity/trufflehog:<version>`
+      # and that input defaults to the MUTABLE `latest` tag, the same
+      # class of mutable ref that got Trivy's @master pinned earlier.
       - name: Check for secrets (blocking)
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
           path: ./
+          version: v3.96.0
           extra_args: --results=verified
 
       # Second, complementary net. --results=verified above means

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,11 +223,14 @@ jobs:
       # runs `docker run ghcr.io/trufflesecurity/trufflehog:<version>`
       # and that input defaults to the MUTABLE `latest` tag, the same
       # class of mutable ref that got Trivy's @master pinned earlier.
+      # NOTE the tag has NO `v` prefix: the git tag is v3.96.0 but the
+      # GHCR tag is 3.96.0. `v3.96.0` is a 404 and docker run exits 125
+      # (image pull failure), which reads as a scan failure, not a typo.
       - name: Check for secrets (blocking)
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
           path: ./
-          version: v3.96.0
+          version: 3.96.0
           extra_args: --results=verified
 
       # Second, complementary net. --results=verified above means

--- a/README.md
+++ b/README.md
@@ -857,7 +857,7 @@ Modern Rust-based replacements for traditional Unix tools:
 | - | **mergiraf** | Syntax-aware merge conflict resolver | (git driver) |
 | - | **posting** | API-testing TUI, requests as YAML | `posting` |
 | `thefuck` | **pay-respects** | Command correction (Rust, cargo) | `fk` |
-| - | **gitleaks** | Secret scan in the pre-commit hook | `gitleaks` |
+| - | **gitleaks** | Secret scan: pre-commit hook + CI | `gitleaks` |
 | - | **zizmor** | GitHub Actions security audit (CI) | `zizmor` |
 | - | **actionlint** | GitHub Actions workflow linter (CI) | `actionlint` |
 

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -503,8 +503,17 @@ cat > "$CRED_DENY_FILE" <<'CRED_EOF'
 \.(pem|p12|pfx)$
 \.(bak|orig)$
 CRED_EOF
+# *.pub is PUBLIC key material and legitimately trackable — .ssh/id_
+# would otherwise flag id_ed25519.pub, which is the same class as the
+# already-tracked .ssh/allowed_signers. Filter before matching.
 run_test "No credential files tracked (public repo)" \
-    "! { yadm ls-files 2>/dev/null || git ls-files 2>/dev/null; } | grep -qEf '$CRED_DENY_FILE'"
+    "! { yadm ls-files 2>/dev/null || git ls-files 2>/dev/null; } |
+     grep -v '\.pub\$' | grep -qEf '$CRED_DENY_FILE'"
+# An empty listing greps clean and passes — the exact vacuous-pass this
+# section exists to prevent (yadm present but silent never trips the
+# || fallback). Assert the list has a plausible floor.
+run_test "credential scan ran against a non-empty file list" \
+    "[ \"\$({ yadm ls-files 2>/dev/null || git ls-files 2>/dev/null; } | wc -l)\" -gt 50 ]"
 # Test the test: a denylist that matches nothing passes vacuously, which
 # is how a scanner rots into decoration. Canary paths are never real
 # files here — they only prove the pattern set still bites.

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -473,6 +473,12 @@ if [ -f "$HOME/.github/workflows/ci.yml" ]; then
     run_test "CI runs gitleaks as a blocking secret scan" \
         "grep -qE 'gitleaks/v8@v[0-9]+\.[0-9]+\.[0-9]+' $HOME/.github/workflows/ci.yml &&
          ! grep -B8 -A4 'gitleaks/v8@v' $HOME/.github/workflows/ci.yml | grep -q 'continue-on-error'"
+    # The action SHA does not pin the scanner it docker-runs; that input
+    # defaults to the mutable `latest`. Bare semver, no `v` — the GHCR
+    # tag is 3.96.0 while the git tag is v3.96.0, and the wrong one is a
+    # 404 that surfaces as docker exit 125, i.e. a scan "failure".
+    run_test "CI pins the TruffleHog scanner version (not latest)" \
+        "grep -qE '^ *version: [0-9]+\.[0-9]+\.[0-9]+ *\$' $HOME/.github/workflows/ci.yml"
 fi
 
 # Credential files must NEVER become tracked in this PUBLIC repo. The

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -455,7 +455,63 @@ fi
 if [ -f "$HOME/.github/workflows/ci.yml" ]; then
     run_test "CI checkouts all set persist-credentials false" \
         "[ \"\$(grep -c 'uses: actions/checkout@' $HOME/.github/workflows/ci.yml)\" -eq \"\$(grep -c 'persist-credentials: false' $HOME/.github/workflows/ci.yml)\" ]"
+    # A secret scanner on a shallow checkout sees ONE commit while
+    # reporting success — the same false-pass class as running gitleaks
+    # outside a repo ("0 commits scanned … no leaks found"). The
+    # security-scan job scans history, so it must fetch it.
+    run_test "CI security scan checks out full history (fetch-depth 0)" \
+        "grep -q 'fetch-depth: 0' $HOME/.github/workflows/ci.yml"
+    # TruffleHog runs --results=verified (zero false positives, but it
+    # only fails on credentials it could confirm live against a
+    # provider). gitleaks is the regex/entropy net that catches private
+    # keys, revoked-but-real tokens and anything unverifiable, and it is
+    # the same engine the yadm pre_commit hook runs — the hook is
+    # bypassable (--no-verify), so CI must own the authoritative copy.
+    # Version-pinned (never @latest — same supply-chain rule as the
+    # SHA-pinned actions) and blocking (no continue-on-error anywhere in
+    # the step, which is what made the old Trivy scan decorative).
+    run_test "CI runs gitleaks as a blocking secret scan" \
+        "grep -qE 'gitleaks/v8@v[0-9]+\.[0-9]+\.[0-9]+' $HOME/.github/workflows/ci.yml &&
+         ! grep -B8 -A4 'gitleaks/v8@v' $HOME/.github/workflows/ci.yml | grep -q 'continue-on-error'"
 fi
+
+# Credential files must NEVER become tracked in this PUBLIC repo. The
+# CLAUDE.md invariant is that identity and secrets live in UNTRACKED
+# files; until now nothing enforced it, and a single `yadm add -A` on a
+# new machine would publish them. Content scanners do not cover this:
+# a ~/.gitconfig holding a corp identity, or a gh hosts.yml token no
+# scanner can verify, is secret-BEARING without being secret-SHAPED.
+CRED_DENY_FILE=$(mktemp)
+cat > "$CRED_DENY_FILE" <<'CRED_EOF'
+^\.gitconfig$
+^\.netrc$
+^\.npmrc$
+^\.pypirc$
+^\.env$
+^\.secrets$
+^\.aws/
+^\.config/gh/hosts\.yml$
+^\.config/op/
+^\.docker/config\.json$
+^\.kube/config$
+^\.ssh/id_
+^\.local/share/atuin/key$
+^\.claude/settings\.local\.json$
+^\.zshrc\.local$
+^\.zshenv\.local$
+^\.daily-maintenance\.local$
+\.(pem|p12|pfx)$
+\.(bak|orig)$
+CRED_EOF
+run_test "No credential files tracked (public repo)" \
+    "! { yadm ls-files 2>/dev/null || git ls-files 2>/dev/null; } | grep -qEf '$CRED_DENY_FILE'"
+# Test the test: a denylist that matches nothing passes vacuously, which
+# is how a scanner rots into decoration. Canary paths are never real
+# files here — they only prove the pattern set still bites.
+run_test "credential denylist actually matches a canary path" \
+    "printf '%s\n' .aws/credentials .config/gh/hosts.yml .ssh/id_ed25519 .gitconfig |
+     [ \"\$(grep -cEf '$CRED_DENY_FILE')\" -eq 4 ]"
+rm -f "$CRED_DENY_FILE"
 echo
 
 # Test 12: Git/yadm checks


### PR DESCRIPTION
Stacked on #80 (base is that branch, so this diff shows only the security changes; GitHub retargets to master when #80 merges).

## Audit result first

**The repo is clean today.** gitleaks over the full history reports **0 leaks across 116 commits**, and no credential path is tracked. The problem was that CI would not reliably have told us otherwise.

## Gaps found and fixed

**1. Secret scanning ran on a shallow checkout.** `actions/checkout` defaults to `fetch-depth: 1`. Demonstrated: a shallow clone reports `1 commits scanned ... no leaks found`; a full clone reports `115 commits scanned ... no leaks found`. Both say 'no leaks found'. Fixed with `fetch-depth: 0`.

**2. TruffleHog scans a DIFF, not full history** — verified by reading `action.yml` at the pinned SHA: with only `path` set it derives BASE/HEAD from the event (push → before..after, PR → base.sha..head.sha) and scans everything only on `workflow_dispatch`/`schedule`. The old comment claimed full history. Corrected, and a **weekly schedule trigger** added so its verified-credential scan eventually covers every commit. `fetch-depth: 0` remains required — those base shas cannot resolve in a depth-1 clone.

**3. The scanner binary was not pinned.** The action's `version` input defaults to the **mutable `latest`** Docker tag, so the SHA-pinned action still ran `docker run ghcr.io/trufflesecurity/trufflehog:latest` — the same mutable-ref class that got Trivy's `@master` pinned earlier. Now `version: v3.96.0`.

**4. `--results=verified` only fails on provider-confirmed credentials.** Private key blocks, revoked-but-real tokens, passwords and unverifiable providers pass silently. Added **gitleaks v8.30.1** (`go install`, the actionlint pattern; module path `zricethezav/gitleaks/v8` is the maintained one — the `gitleaks/gitleaks` mirror stops at v8.15.3) as a blocking **full-history** net. It is the same engine the yadm `pre_commit` hook runs, and that hook is bypassable (`--no-verify`), so CI now owns the authoritative copy. Measured on a real full clone: 116 commits, 0 findings, 164 ms — no noise; the AWS doc-example keys are allowlisted by the default ruleset.

**5. Secret-BEARING vs secret-SHAPED.** Content scanners match secret-shaped strings. The CLAUDE.md invariant is that identity lives in **untracked** files, and nothing enforced it — one `yadm add -A` would publish `~/.gitconfig`, `.config/gh/hosts.yml`, `.aws/credentials` or an atuin key with no scanner objecting. Added a tracked-path denylist covering those plus `.netrc`/`.npmrc`/`.pypirc`, `.docker/config.json`, `.kube/config`, `.ssh/id_*`, `*.pem|p12|pfx`, machine-local overrides and `*.bak|orig`. `*.pub` is filtered first so public key material (same class as the tracked `.ssh/allowed_signers`) cannot trip it.

## Anti-rot

Every check ships with an assertion that it still bites: the denylist matches 4/4 canary paths, the file listing has a floor (an empty list would otherwise grep clean and pass), and CI-shape tests assert `fetch-depth: 0` is present and the gitleaks step is version-pinned and not `continue-on-error`. That vacuous-pass class is the whole subject of this PR.

## Out of scope for CI

GitHub **push protection** blocks a secret before it becomes public — the only control CI structurally cannot provide, since after a push to a public repo the remedy is rotation, not reverting. Already enabled on this repo (secret scanning + push protection); the remaining toggle is *non-provider patterns*, which is UI-only.

Suite 125/125, markdownlint clean, yamllint (relaxed, as CI runs it) clean.