### PR TITLE
fix(bootstrap): create ~/.ssh/sockets for ControlMaster

### DIFF
--- a/.config/yadm/bootstrap
+++ b/.config/yadm/bootstrap
@@ -330,6 +330,13 @@ if command -v nvim &> /dev/null; then
     echo "  ✓ Treesitter parsers installed"
 fi
 
+# SSH ControlMaster socket dir — 00-defaults.conf sets
+# ControlPath ~/.ssh/sockets/%r@%h-%p but ssh never creates the
+# directory itself; without it every connection fails with
+# "unix_listener: cannot bind" (bit us live 2026-08-08).
+mkdir -p "$HOME/.ssh/sockets" && chmod 700 "$HOME/.ssh/sockets"
+echo "  ✓ ~/.ssh/sockets ready (ControlMaster)"
+
 # Final self-verification: the suite encodes every cross-machine
 # assumption (services, plugin sets, config schemas) — running it here
 # turns "bootstrap finished" into "bootstrap verified".


### PR DESCRIPTION
Picked up an unpushed local commit from 2026-08-07 and pushed it through the normal PR path (master is protected).

## The fix

`00-defaults.conf` sets `ControlPath ~/.ssh/sockets/%r@%h-%p`, but ssh never creates that directory. On a fresh machine every connection fails with `unix_listener: cannot bind` — hit live on 2026-08-08. Bootstrap now creates it with mode 700.

## Two things fixed before pushing

1. **Mojibake in the status line.** The `✓` was double-encoded (`c3 a2 c2 9c c2 93` instead of `e2 9c 93`), so bootstrap would print `â` garbage on every fresh machine — the one place where output is read carefully. Restored to a proper U+2713.
2. **Author identity.** The commit was authored as `nickboy@NickdeMac-mini.local`, which publishes a machine hostname into a public repo and is not the configured identity. Re-authored to `nickboy@users.noreply.github.com`; the original author date is preserved.

## Known gap

The commit is unsigned. This machine has no signing config at all (`commit.gpgsign`, `gpg.format`, `user.signingkey` are all unset for yadm), so it cannot be signed here — that needs the 1Password agent setup. Not a blocker, but worth knowing the machine is in that state.

Suite 128/128 locally; `bash -n` and shellcheck clean on the bootstrap script.