### PR TITLE
feat(statusline): report context percentage to HerdDeck's Stream Deck donut

### DIFF
--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -79,6 +79,25 @@ PCT=${PCT_RAW%.*}
 FIVE_H_INT=${FIVE_H%.*}
 SEVEN_D_INT=${SEVEN_D%.*}
 
+# Feed HerdDeck's Stream Deck context donut with the percentage we just
+# parsed. Claude Code is the only thing that knows it, and the
+# statusline is the only place it surfaces — so the donut has to be fed
+# from here or it stays dark.
+#
+# The reporter writes ctx_pct to the herdr server of whichever machine
+# this agent runs on (via herdr's injected HERDR_PANE_ID /
+# HERDR_SOCKET_PATH), so a HerdDeck daemon on another machine picks it
+# up through the SSH tunnel already forwarding that socket. It is a
+# silent no-op outside a herdr pane, when herdr is stopped, or when
+# HerdDeck isn't installed.
+#
+# Backgrounded with stdout/stderr closed: a hung socket must never
+# stall the prompt, and an inherited stdout would leave Claude Code
+# waiting on EOF.
+if command -v herddeck-report-ctx >/dev/null 2>&1; then
+    herddeck-report-ctx "$PCT" >/dev/null 2>&1 &
+fi
+
 # -----------------------------------------------------------------------------
 # Colors — Catppuccin Mocha palette (24-bit truecolor) to match starship/tmux
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Why

HerdDeck's Stream Deck Agent Slot keys have a context-window donut that
never lit up. herdr can only display a context percentage that something
reports to it, and Claude Code surfaces that number in exactly one
place — the statusline's stdin JSON. So the statusline is the only thing
positioned to feed it.

## What

One line where the percentage is already parsed, handed to HerdDeck's
`herddeck-report-ctx`:

```bash
if command -v herddeck-report-ctx >/dev/null 2>&1; then
    herddeck-report-ctx "$PCT" >/dev/null 2>&1 &
fi
```

The reporter writes to the herdr server of whichever machine the agent
runs on, which is what makes this work over SSH: a HerdDeck daemon on
another machine reads the value back through the tunnel already
forwarding that socket.

## Inert where it doesn't apply

Guarded by `command -v`, so it is a no-op on any machine without
HerdDeck installed — nothing to configure per-machine, nothing to break
on a work box. The reporter itself is separately silent outside a herdr
pane and when herdr is stopped.

Backgrounded with stdout and stderr closed: a hung socket must never
stall the prompt, and an inherited stdout would leave Claude Code
waiting on EOF.

## Verified

Live on this machine — all four panes of the running herdr session went
from a single stale frozen value to four distinct live percentages
(`13` / `34` / `43` / `16`).

Full suite green: 128 tests, shellcheck clean, gitleaks clean.