### PR TITLE
feat(statusline): mirror a mid-session /rename onto the herdr tab

### DIFF
--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -27,7 +27,7 @@ IFS=$'\x1f' read -r \
     SESSION_ID MODEL DIR EFFORT_STDIN \
     PCT_RAW COST_RAW DURATION_MS \
     FIVE_H FIVE_H_RESET \
-    SEVEN_D SEVEN_D_RESET < <(
+    SEVEN_D SEVEN_D_RESET SESSION_NAME < <(
     printf '%s' "$INPUT" | jq -r '
         [
             (.session_id // "nosession"),
@@ -40,7 +40,8 @@ IFS=$'\x1f' read -r \
             (.rate_limits.five_hour.used_percentage // -1),
             (.rate_limits.five_hour.resets_at // .rate_limits.five_hour.reset_at // ""),
             (.rate_limits.seven_day.used_percentage // -1),
-            (.rate_limits.seven_day.resets_at // .rate_limits.seven_day.reset_at // "")
+            (.rate_limits.seven_day.resets_at // .rate_limits.seven_day.reset_at // ""),
+            (.session_name // "")
         ] | map(tostring) | join("")
     ' 2>/dev/null
 )
@@ -96,6 +97,29 @@ SEVEN_D_INT=${SEVEN_D%.*}
 # waiting on EOF.
 if command -v herddeck-report-ctx >/dev/null 2>&1; then
     herddeck-report-ctx "$PCT" >/dev/null 2>&1 &
+fi
+
+# Mirror a mid-session /rename onto the herdr tab — the tmux
+# automatic-rename equivalent, which herdr has no built-in setting for.
+#
+# claude-name-session already names the tab, but only fires on
+# SessionStart, so a /rename halfway through a session left the tab on
+# its old name. The statusline is the only thing Claude Code runs every
+# turn that knows the current title (`.session_name`).
+#
+# ONLY on change, and never on the first sighting of a session. Renaming
+# every turn would clobber hand-named tabs ("Reviewer", "Dotfiles") with
+# whatever the pane's agent happens to be called, and seeding the cache
+# silently means a fresh cache (reboot, /tmp wipe) costs one turn of lag
+# instead of destroying those names.
+if [ -n "${HERDR_TAB_ID:-}" ] && [ -n "${SESSION_NAME:-}" ] && command -v herdr >/dev/null 2>&1; then
+    NAME_CACHE="/tmp/claude-statusline-name-${SESSION_ID}"
+    PREV_NAME=$(cat "$NAME_CACHE" 2>/dev/null || printf '')
+    if [ "$PREV_NAME" != "$SESSION_NAME" ]; then
+        printf '%s' "$SESSION_NAME" > "$NAME_CACHE" 2>/dev/null
+        [ -n "$PREV_NAME" ] &&
+            herdr tab rename "$HERDR_TAB_ID" "$SESSION_NAME" >/dev/null 2>&1 &
+    fi
 fi
 
 # -----------------------------------------------------------------------------

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -733,6 +733,39 @@ CCL_HERDR2
     rm -rf "$CCL_TMP"
 fi
 
+# claude-statusline mirrors a mid-session /rename onto the herdr tab.
+# The dangerous case is over-firing: renaming on every turn would
+# overwrite hand-named tabs ("Reviewer") with the pane's agent name, so
+# assert BOTH that a rename propagates and that nothing fires on a
+# first sighting or an unchanged name. Stub herdr logs its argv; the
+# rename is backgrounded so each run gets a moment to land.
+if [ -x "$HOME/.local/bin/claude-statusline" ] && command -v jq >/dev/null 2>&1; then
+    CS_TMP=$(mktemp -d)
+    mkdir -p "$CS_TMP/bin"
+    printf '#!/bin/sh\necho "$*" >> "%s/calls.log"\n' "$CS_TMP" > "$CS_TMP/bin/herdr"
+    chmod +x "$CS_TMP/bin/herdr"
+    : > "$CS_TMP/calls.log"
+    cs_payload() {
+        printf '{"session_id":"utcs","session_name":"%s","model":{"display_name":"O"},"workspace":{"current_dir":"%s"},"context_window":{"used_percentage":5},"cost":{"total_cost_usd":0,"total_duration_ms":0},"rate_limits":{}}' "$1" "$HOME"
+    }
+    cs_run() {
+        cs_payload "$1" | env PATH="$CS_TMP/bin:$PATH" HERDR_TAB_ID=w1:t9 \
+            "$HOME/.local/bin/claude-statusline" >/dev/null 2>&1
+        sleep 0.4
+    }
+    rm -f /tmp/claude-statusline-name-utcs
+    cs_run alpha
+    run_test "claude-statusline: first sighting seeds without renaming the tab" \
+        "[ ! -s '$CS_TMP/calls.log' ] && [ \"\$(cat /tmp/claude-statusline-name-utcs)\" = alpha ]"
+    cs_run alpha
+    run_test "claude-statusline: an unchanged session name renames nothing" \
+        "[ ! -s '$CS_TMP/calls.log' ]"
+    cs_run beta
+    run_test "claude-statusline: a /rename propagates to the herdr tab" \
+        "[ \"\$(cat '$CS_TMP/calls.log')\" = 'tab rename w1:t9 beta' ]"
+    rm -rf "$CS_TMP" /tmp/claude-statusline-name-utcs
+fi
+
 # gitleaks pre-commit engine: same invocation the yadm hook uses, against
 # a throwaway fixture repo (plain git on purpose — the yadm-only rule is
 # for the dotfiles repo, not isolated fixtures). The canary is assembled


### PR DESCRIPTION
## The bug

`/rename` mid-session left the herdr tab showing the name it was born
with.

`claude-name-session` already renames the tab — but it is a
**SessionStart** hook, so it fires on startup and resume and never
again. And herdr has no automatic-rename setting (I checked the whole
default config), so nothing else was going to do it.

## Why the statusline

It is the only thing Claude Code runs every turn that knows the current
title. Verified against a live payload capture — `.session_name` is
right there:

```
session_name = 'home'
context_window.used_percentage = 43
```

Same mechanism as the context donut, one file over.

## Rename only on change — and never on first sighting

This is the part that matters. Renaming on every turn would overwrite
hand-named tabs (`Reviewer`, `Dotfiles`, `Herddeck`) with whatever the
pane's agent happens to be called. Seeding the cache silently on the
first sighting means a cold `/tmp` (reboot) costs one turn of lag
instead of destroying those names.

Backgrounded, guarded on `HERDR_TAB_ID` and `herdr` being on `PATH`, so
it is inert outside a herdr pane and can never stall the prompt.

## Tests

Three, and two of them exist for the over-firing risk rather than the
feature:

- first sighting seeds the cache and renames **nothing**
- an unchanged session name produces **no call at all**
- a `/rename` propagates exactly one `tab rename <tab> <name>`

131 tests pass.