### PR TITLE
fix(statusline): heal a herdr tab renamed out from under this session

### DIFF
--- a/.local/bin/claude-name-session
+++ b/.local/bin/claude-name-session
@@ -45,9 +45,20 @@ emit() {  # $1 = title
 # Inside a herdr pane, mirror the title onto the herdr TAB — the
 # equivalent of the tmux window rename that set-titles forwards.
 # Best-effort and stdout-silent: hook output must stay pure JSON.
+#
+# herdr has no provenance on tab names: `tab rename` is a bare string
+# setter with no source field, so nothing downstream can tell a name a
+# script wrote from one a person typed (verified against 0.8.0 —
+# Tab holds only `custom_name: Option<String>`). Every writer therefore
+# records what it set, keyed by TAB so other sessions can see it, and
+# claude-statusline reclaims only values that appear in that record.
+# Without this line a name written here is indistinguishable from a
+# hand-typed one and can never be repaired. Same convention as the
+# ecosystem's tab-rename plugins, which all converged on it.
 herdr_tab_name() {  # $1 = title
     [ -n "${HERDR_TAB_ID:-}" ] || return 0
     have herdr || return 0
+    printf '%s' "$1" > "/tmp/claude-tabname-${HERDR_TAB_ID//:/-}" 2>/dev/null || true
     herdr tab rename "$HERDR_TAB_ID" "$1" >/dev/null 2>&1 || true
 }
 

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -206,11 +206,28 @@ if [ "${SHOW_HERDR:-1}" = 1 ] && [ -n "${HERDR_TAB_ID:-}" ] &&
                     # also the rule every tab-rename plugin in the
                     # ecosystem independently arrived at.
                     #
+                    # DO NOT "improve" the all-digits test into a
+                    # comparison against this tab's `number` field, even
+                    # though it sits in the same JSON. They are different
+                    # things: the default label is `tab_idx + 1`
+                    # (positional), while `number` comes from
+                    # next_public_tab_number and is never reused. Close
+                    # one tab and an unnamed tab can display "4" while
+                    # the API reports number=5 — so that comparison would
+                    # stop recognising the default exactly on a
+                    # long-lived session, which is when it matters.
+                    # Costs one real edge: someone naming a tab "2024"
+                    # is read as unnamed and reclaimed once.
+                    #
                     # KNOWN LIMIT: two sessions that both believe they
                     # own one tab still alternate, once a minute each.
-                    # No local signal resolves that — it needs real
-                    # ownership, i.e. matching this process's tty
-                    # against the pane's. Follow-up.
+                    # The root fix is to verify the inherited
+                    # HERDR_TAB_ID rather than trust it — walk this
+                    # process's ancestry and intersect it with each
+                    # pane's shell_pid/foreground pids from
+                    # `pane process-info`, which identifies the pane
+                    # genuinely containing us. Buildable on 0.8.0 today;
+                    # cache it once per session, not per tick. Follow-up.
                     _mark=$(cat "$TAB_MARK" 2>/dev/null || printf '')
                     if [ "$_actual" = "$_mark" ]; then
                         claim_tab

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -133,11 +133,41 @@ if [ "${SHOW_HERDR:-1}" = 1 ] && [ -n "${HERDR_TAB_ID:-}" ] &&
    [ -n "${SESSION_NAME:-}" ] && command -v herdr >/dev/null 2>&1; then
     NAME_CACHE="/tmp/claude-statusline-name-${SESSION_ID}"
     PREV_NAME=$(cat "$NAME_CACHE" 2>/dev/null || printf '')
+    NEEDS_RENAME=0
+
     if [ "$PREV_NAME" != "$SESSION_NAME" ]; then
         printf '%s' "$SESSION_NAME" > "$NAME_CACHE" 2>/dev/null
-        [ -n "$PREV_NAME" ] &&
-            herdr tab rename "$HERDR_TAB_ID" "$SESSION_NAME" >/dev/null 2>&1 &
+        # Never on first sighting — see above.
+        [ -n "$PREV_NAME" ] && NEEDS_RENAME=1
+    else
+        # The cache says we are up to date, but it records what this
+        # SESSION was last called, not what the TAB is actually labelled.
+        # HERDR_TAB_ID is inherited from the launching pane, so a session
+        # started from one pane while working in another directory renames
+        # a tab it does not own — observed live: this tab was relabelled
+        # "herddeck/feat/per-model-weekly" by a session in another repo.
+        # Comparing names alone can never recover from that: renaming back
+        # to the same value looks like "no change" and does nothing.
+        # So re-read the real label periodically. Bounded to once a minute
+        # because the statusline runs every refreshInterval (5s) and this
+        # costs a socket round-trip; drift is cosmetic, so healing within
+        # a minute is ample.
+        TAB_STAMP="/tmp/claude-statusline-tabcheck-${SESSION_ID}"
+        _now=$(date +%s)
+        _last=$(stat -f %m "$TAB_STAMP" 2>/dev/null || printf '0')
+        if [ $(( _now - _last )) -ge 60 ]; then
+            : > "$TAB_STAMP" 2>/dev/null
+            ACTUAL_LABEL=$(herdr tab list 2>/dev/null |
+                jq -r --arg id "$HERDR_TAB_ID" \
+                    '.result.tabs[]? | select(.tab_id == $id) | .label // empty' \
+                2>/dev/null)
+            [ -n "$ACTUAL_LABEL" ] && [ "$ACTUAL_LABEL" != "$SESSION_NAME" ] &&
+                NEEDS_RENAME=1
+        fi
     fi
+
+    [ "$NEEDS_RENAME" = 1 ] &&
+        herdr tab rename "$HERDR_TAB_ID" "$SESSION_NAME" >/dev/null 2>&1 &
 fi
 
 # -----------------------------------------------------------------------------

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -171,15 +171,27 @@ if [ "${SHOW_HERDR:-1}" = 1 ] && [ -n "${HERDR_TAB_ID:-}" ] &&
                         '.result.tabs[]? | select(.tab_id == $id) | .label // empty' \
                     2>/dev/null)
                 if [ -n "$_actual" ] && [ "$_actual" != "$SESSION_NAME" ]; then
-                    # ONLY reclaim a label that another session's naming
-                    # produced. claude-name-session writes "project/branch"
-                    # (or "host:project/branch"), so a slash marks a
-                    # machine-generated name. A label without one —
-                    # "Reviewer", "scratchpad" — is a human's choice and
-                    # must survive: a hand-named tab and a stolen one are
-                    # otherwise indistinguishable, and clobbering the
-                    # human is far worse than leaving a stale label.
+                    # A hand-named tab and a stolen one look identical
+                    # here — label != session name is the only signal —
+                    # and clobbering a human's choice is far worse than
+                    # leaving a stale label. So reclaim ONLY names that
+                    # are provably machine-made, and accept missing some.
+                    #
+                    # A slash is that proof: claude-name-session appends
+                    # "/branch" only for a NON-default branch. On main,
+                    # master, trunk, a detached head, or a non-git
+                    # directory it emits a bare project name with no
+                    # slash — "Herddeck", "home" — which this rule
+                    # cannot tell from a person typing "Reviewer", so a
+                    # tab stolen by a session on a default branch stays
+                    # stolen. Under-reclaiming leaves a stale label,
+                    # which is what happened before any of this existed.
                     # Rename the SESSION if you want the tab to follow.
+                    #
+                    # The real fix is to stop inferring: have every
+                    # machine writer record the label it set, keyed by
+                    # tab, and reclaim only recorded values. Then shape
+                    # stops mattering. Follow-up.
                     case "$_actual" in
                         */*) herdr tab rename "$HERDR_TAB_ID" "$SESSION_NAME" \
                                 >/dev/null 2>&1 ;;

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -133,12 +133,12 @@ if [ "${SHOW_HERDR:-1}" = 1 ] && [ -n "${HERDR_TAB_ID:-}" ] &&
    [ -n "${SESSION_NAME:-}" ] && command -v herdr >/dev/null 2>&1; then
     NAME_CACHE="/tmp/claude-statusline-name-${SESSION_ID}"
     PREV_NAME=$(cat "$NAME_CACHE" 2>/dev/null || printf '')
-    NEEDS_RENAME=0
 
     if [ "$PREV_NAME" != "$SESSION_NAME" ]; then
         printf '%s' "$SESSION_NAME" > "$NAME_CACHE" 2>/dev/null
         # Never on first sighting — see above.
-        [ -n "$PREV_NAME" ] && NEEDS_RENAME=1
+        [ -n "$PREV_NAME" ] &&
+            herdr tab rename "$HERDR_TAB_ID" "$SESSION_NAME" >/dev/null 2>&1 &
     else
         # The cache says we are up to date, but it records what this
         # SESSION was last called, not what the TAB is actually labelled.
@@ -154,20 +154,40 @@ if [ "${SHOW_HERDR:-1}" = 1 ] && [ -n "${HERDR_TAB_ID:-}" ] &&
         # a minute is ample.
         TAB_STAMP="/tmp/claude-statusline-tabcheck-${SESSION_ID}"
         _now=$(date +%s)
-        _last=$(stat -f %m "$TAB_STAMP" 2>/dev/null || printf '0')
+        # BSD stat here, GNU stat on a Linux herdr server. Without the
+        # fallback _last stays 0 there and the check fires every tick.
+        _last=$(stat -f %m "$TAB_STAMP" 2>/dev/null ||
+                stat -c %Y "$TAB_STAMP" 2>/dev/null || printf '0')
         if [ $(( _now - _last )) -ge 60 ]; then
+            # Stamp BEFORE the query so backgrounded checks cannot pile
+            # up: the next tick sees it fresh and skips.
             : > "$TAB_STAMP" 2>/dev/null
-            ACTUAL_LABEL=$(herdr tab list 2>/dev/null |
-                jq -r --arg id "$HERDR_TAB_ID" \
-                    '.result.tabs[]? | select(.tab_id == $id) | .label // empty' \
-                2>/dev/null)
-            [ -n "$ACTUAL_LABEL" ] && [ "$ACTUAL_LABEL" != "$SESSION_NAME" ] &&
-                NEEDS_RENAME=1
+            # Backgrounded like the rename above, and for the same
+            # reason: this contributes nothing to the rendered line, and
+            # a restarting server is exactly when a socket read blocks.
+            (
+                _actual=$(herdr tab list 2>/dev/null |
+                    jq -r --arg id "$HERDR_TAB_ID" \
+                        '.result.tabs[]? | select(.tab_id == $id) | .label // empty' \
+                    2>/dev/null)
+                if [ -n "$_actual" ] && [ "$_actual" != "$SESSION_NAME" ]; then
+                    # ONLY reclaim a label that another session's naming
+                    # produced. claude-name-session writes "project/branch"
+                    # (or "host:project/branch"), so a slash marks a
+                    # machine-generated name. A label without one —
+                    # "Reviewer", "scratchpad" — is a human's choice and
+                    # must survive: a hand-named tab and a stolen one are
+                    # otherwise indistinguishable, and clobbering the
+                    # human is far worse than leaving a stale label.
+                    # Rename the SESSION if you want the tab to follow.
+                    case "$_actual" in
+                        */*) herdr tab rename "$HERDR_TAB_ID" "$SESSION_NAME" \
+                                >/dev/null 2>&1 ;;
+                    esac
+                fi
+            ) &
         fi
     fi
-
-    [ "$NEEDS_RENAME" = 1 ] &&
-        herdr tab rename "$HERDR_TAB_ID" "$SESSION_NAME" >/dev/null 2>&1 &
 fi
 
 # -----------------------------------------------------------------------------

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -133,12 +133,30 @@ if [ "${SHOW_HERDR:-1}" = 1 ] && [ -n "${HERDR_TAB_ID:-}" ] &&
    [ -n "${SESSION_NAME:-}" ] && command -v herdr >/dev/null 2>&1; then
     NAME_CACHE="/tmp/claude-statusline-name-${SESSION_ID}"
     PREV_NAME=$(cat "$NAME_CACHE" 2>/dev/null || printf '')
+    # Keyed by TAB, not session: a tab stolen by another session has to
+    # be recognisable to the session it was stolen from.
+    TAB_MARK="/tmp/claude-tabname-${HERDR_TAB_ID//:/-}"
+
+    # Claim the tab AND record that a machine set this label. herdr's
+    # tab.rename carries no source field, so this record is the only way
+    # anything can later tell a scripted name from a typed one.
+    claim_tab() {
+        printf '%s' "$SESSION_NAME" > "$TAB_MARK" 2>/dev/null
+        herdr tab rename "$HERDR_TAB_ID" "$SESSION_NAME" >/dev/null 2>&1
+    }
 
     if [ "$PREV_NAME" != "$SESSION_NAME" ]; then
         printf '%s' "$SESSION_NAME" > "$NAME_CACHE" 2>/dev/null
+        # The OFFICIAL channel for agent identity: pane metadata is
+        # per-source, so several sessions sharing a pane each get their
+        # own slot instead of overwriting one string. Unlike the tab
+        # name this cannot collide, so it is reported even on first
+        # sighting. herdr's own docs point hooks here.
+        ( herdr pane report-metadata "${HERDR_PANE_ID:-}" \
+            --source "claude-${SESSION_ID}" \
+            --display-agent "$SESSION_NAME" >/dev/null 2>&1 ) &
         # Never on first sighting — see above.
-        [ -n "$PREV_NAME" ] &&
-            herdr tab rename "$HERDR_TAB_ID" "$SESSION_NAME" >/dev/null 2>&1 &
+        [ -n "$PREV_NAME" ] && claim_tab &
     else
         # The cache says we are up to date, but it records what this
         # SESSION was last called, not what the TAB is actually labelled.
@@ -171,31 +189,37 @@ if [ "${SHOW_HERDR:-1}" = 1 ] && [ -n "${HERDR_TAB_ID:-}" ] &&
                         '.result.tabs[]? | select(.tab_id == $id) | .label // empty' \
                     2>/dev/null)
                 if [ -n "$_actual" ] && [ "$_actual" != "$SESSION_NAME" ]; then
-                    # A hand-named tab and a stolen one look identical
-                    # here — label != session name is the only signal —
-                    # and clobbering a human's choice is far worse than
-                    # leaving a stale label. So reclaim ONLY names that
-                    # are provably machine-made, and accept missing some.
+                    # Reclaim only what a machine provably wrote. Two
+                    # such labels exist: one some writer recorded in
+                    # TAB_MARK, and herdr's own default, which
+                    # tab_display_name renders as the bare tab NUMBER
+                    # when custom_name is unset. Anything else was typed
+                    # by a person and is left alone permanently — a
+                    # hand-named tab and a stolen one are otherwise
+                    # identical, and overwriting someone's choice is far
+                    # worse than leaving a stale label.
                     #
-                    # A slash is that proof: claude-name-session appends
-                    # "/branch" only for a NON-default branch. On main,
-                    # master, trunk, a detached head, or a non-git
-                    # directory it emits a bare project name with no
-                    # slash — "Herddeck", "home" — which this rule
-                    # cannot tell from a person typing "Reviewer", so a
-                    # tab stolen by a session on a default branch stays
-                    # stolen. Under-reclaiming leaves a stale label,
-                    # which is what happened before any of this existed.
-                    # Rename the SESSION if you want the tab to follow.
+                    # This replaces guessing at the name's SHAPE. That
+                    # guess (a slash means machine-made) missed every
+                    # session on main/master/trunk, since
+                    # claude-name-session omits "/branch" there. It is
+                    # also the rule every tab-rename plugin in the
+                    # ecosystem independently arrived at.
                     #
-                    # The real fix is to stop inferring: have every
-                    # machine writer record the label it set, keyed by
-                    # tab, and reclaim only recorded values. Then shape
-                    # stops mattering. Follow-up.
-                    case "$_actual" in
-                        */*) herdr tab rename "$HERDR_TAB_ID" "$SESSION_NAME" \
-                                >/dev/null 2>&1 ;;
-                    esac
+                    # KNOWN LIMIT: two sessions that both believe they
+                    # own one tab still alternate, once a minute each.
+                    # No local signal resolves that — it needs real
+                    # ownership, i.e. matching this process's tty
+                    # against the pane's. Follow-up.
+                    _mark=$(cat "$TAB_MARK" 2>/dev/null || printf '')
+                    if [ "$_actual" = "$_mark" ]; then
+                        claim_tab
+                    else
+                        case "$_actual" in
+                            *[!0-9]*) ;;          # a person named this
+                            *) claim_tab ;;       # bare number: unnamed
+                        esac
+                    fi
                 fi
             ) &
         fi

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -807,6 +807,19 @@ CS_STUB
     run_test "claude-statusline: leaves a hand-named tab alone" \
         "! grep -q 'tab rename' '$CS_TMP/calls.log'"
 
+    # THE KNOWN LIMIT, pinned deliberately rather than left to be
+    # rediscovered: claude-name-session omits "/branch" on main, master,
+    # trunk and outside git, so a machine name from a default branch is
+    # slash-free and indistinguishable from a hand-typed one. It is NOT
+    # reclaimed. Under-reclaiming leaves a stale label — the behaviour
+    # that predates this feature — which is the safe direction.
+    : > "$CS_TMP/calls.log"
+    cs_label "herddeck"
+    rm -f /tmp/claude-statusline-tabcheck-utcs
+    cs_run beta
+    run_test "claude-statusline: a slash-free machine name is left alone (known limit)" \
+        "! grep -q 'tab rename' '$CS_TMP/calls.log'"
+
     # ...and the check runs at most once a minute, or it degrades into a
     # socket call every 5s. touch (not elapsed wall-clock) decides
     # "not due", so a slow or suspended suite cannot flake this.

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -743,9 +743,20 @@ fi
 if [ -x "$HOME/.local/bin/claude-statusline" ] && command -v jq >/dev/null 2>&1; then
     CS_TMP=$(mktemp -d)
     mkdir -p "$CS_TMP/bin"
-    printf '#!/bin/sh\necho "$*" >> "%s/calls.log"\n' "$CS_TMP" > "$CS_TMP/bin/herdr"
+    # Stub logs argv AND answers `tab list` from a fixture, so a test can
+    # say what the tab is currently labelled and assert the drift repair.
+    cat > "$CS_TMP/bin/herdr" <<CS_STUB
+#!/bin/sh
+echo "\$*" >> "$CS_TMP/calls.log"
+[ "\$1 \$2" = 'tab list' ] && cat "$CS_TMP/tablabel.json" 2>/dev/null
+exit 0
+CS_STUB
     chmod +x "$CS_TMP/bin/herdr"
     : > "$CS_TMP/calls.log"
+    cs_label() {
+        printf '{"result":{"tabs":[{"tab_id":"w1:t9","label":"%s"}]}}' "$1" \
+            > "$CS_TMP/tablabel.json"
+    }
     cs_payload() {
         printf '{"session_id":"utcs","session_name":"%s","model":{"display_name":"O"},"workspace":{"current_dir":"%s"},"context_window":{"used_percentage":5},"cost":{"total_cost_usd":0,"total_duration_ms":0},"rate_limits":{}}' "$1" "$HOME"
     }
@@ -754,17 +765,43 @@ if [ -x "$HOME/.local/bin/claude-statusline" ] && command -v jq >/dev/null 2>&1;
             "$HOME/.local/bin/claude-statusline" >/dev/null 2>&1
         sleep 0.4
     }
-    rm -f /tmp/claude-statusline-name-utcs
+    # Both caches must be cleared: the drift check is throttled by the
+    # mtime of its own stamp file, so a leftover one makes these tests
+    # pass or fail depending on how recently the suite last ran.
+    rm -f /tmp/claude-statusline-name-utcs /tmp/claude-statusline-tabcheck-utcs
+    cs_label alpha
     cs_run alpha
     run_test "claude-statusline: first sighting seeds without renaming the tab" \
-        "[ ! -s '$CS_TMP/calls.log' ] && [ \"\$(cat /tmp/claude-statusline-name-utcs)\" = alpha ]"
+        "! grep -q 'tab rename' '$CS_TMP/calls.log' && [ \"\$(cat /tmp/claude-statusline-name-utcs)\" = alpha ]"
     cs_run alpha
+    # Asserts no WRITE, not no call: the drift check below is a read, and
+    # it is allowed to happen here.
     run_test "claude-statusline: an unchanged session name renames nothing" \
-        "[ ! -s '$CS_TMP/calls.log' ]"
+        "! grep -q 'tab rename' '$CS_TMP/calls.log'"
     cs_run beta
     run_test "claude-statusline: a /rename propagates to the herdr tab" \
-        "[ \"\$(cat '$CS_TMP/calls.log')\" = 'tab rename w1:t9 beta' ]"
-    rm -rf "$CS_TMP" /tmp/claude-statusline-name-utcs
+        "grep -q 'tab rename w1:t9 beta' '$CS_TMP/calls.log'"
+
+    # Drift repair: HERDR_TAB_ID is inherited from the launching pane, so
+    # a session working elsewhere can rename a tab it does not own. The
+    # session name has NOT changed here, so name-comparison alone can
+    # never notice — only re-reading the tab's real label can.
+    : > "$CS_TMP/calls.log"
+    cs_label "stolen-by-another-agent"
+    rm -f /tmp/claude-statusline-tabcheck-utcs   # force the check to be due
+    cs_run beta
+    run_test "claude-statusline: repairs a tab renamed by someone else" \
+        "grep -q 'tab rename w1:t9 beta' '$CS_TMP/calls.log'"
+
+    # ...but only once a minute. The stamp is fresh from the run above,
+    # so a second hijack inside the window must NOT trigger another
+    # query — otherwise the check degrades into a socket call every 5s.
+    : > "$CS_TMP/calls.log"
+    cs_label "stolen-again"
+    cs_run beta
+    run_test "claude-statusline: drift check is throttled to once a minute" \
+        "[ ! -s '$CS_TMP/calls.log' ]"
+    rm -rf "$CS_TMP" /tmp/claude-statusline-name-utcs /tmp/claude-statusline-tabcheck-utcs
 fi
 
 # gitleaks pre-commit engine: same invocation the yadm hook uses, against

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -768,7 +768,7 @@ CS_STUB
     # Both caches must be cleared: the drift check is throttled by the
     # mtime of its own stamp file, so a leftover one makes these tests
     # pass or fail depending on how recently the suite last ran.
-    rm -f /tmp/claude-statusline-name-utcs /tmp/claude-statusline-tabcheck-utcs
+    rm -f /tmp/claude-statusline-name-utcs /tmp/claude-statusline-tabcheck-utcs /tmp/claude-tabname-w1-t9
     cs_label alpha
     cs_run alpha
     run_test "claude-statusline: first sighting seeds without renaming the tab" \
@@ -784,41 +784,58 @@ CS_STUB
     run_test "claude-statusline: a /rename propagates to the herdr tab" \
         "[ \"\$(grep -c 'tab rename w1:t9 beta' '$CS_TMP/calls.log')\" -eq 1 ]"
 
-    # Drift repair: HERDR_TAB_ID is inherited from the launching pane, so
-    # a session working elsewhere can rename a tab it does not own. The
-    # session name has NOT changed here, so name-comparison alone can
-    # never notice — only re-reading the tab's real label can. A slash
-    # marks the "project/branch" shape claude-name-session produces.
+    # Drift repair. HERDR_TAB_ID is inherited from the launching pane, so
+    # a session working elsewhere can rename a tab it does not own; the
+    # session name has NOT changed, so only re-reading the real label can
+    # notice. A label is reclaimable when some writer RECORDED it —
+    # herdr's tab.rename carries no source field, so that record is the
+    # only provenance available.
     : > "$CS_TMP/calls.log"
-    cs_label "herddeck/feat/some-branch"
+    cs_label "home"                              # slash-free ON PURPOSE:
+    printf 'home' > /tmp/claude-tabname-w1-t9    # the shape rule missed this
     rm -f /tmp/claude-statusline-tabcheck-utcs   # force the check to be due
     cs_run beta
-    run_test "claude-statusline: repairs a tab renamed by another session" \
+    run_test "claude-statusline: reclaims a label another writer recorded" \
         "[ \"\$(grep -c 'tab rename w1:t9 beta' '$CS_TMP/calls.log')\" -eq 1 ]"
 
-    # THE LIMIT ON THAT REPAIR. A hand-named tab has no slash and must
-    # survive, or mirroring makes manual names impossible to keep — this
-    # regressed live, clobbering a tab named "Reviewer" back to its
-    # session's "home".
+    # herdr renders an unnamed tab as its bare NUMBER (tab_display_name
+    # falls back to the index when custom_name is unset), so a numeric
+    # label means nobody has claimed it.
+    : > "$CS_TMP/calls.log"
+    cs_label "9"
+    rm -f /tmp/claude-tabname-w1-t9 /tmp/claude-statusline-tabcheck-utcs
+    cs_run beta
+    run_test "claude-statusline: claims an unnamed (numeric) tab" \
+        "[ \"\$(grep -c 'tab rename w1:t9 beta' '$CS_TMP/calls.log')\" -eq 1 ]"
+
+    # THE LIMIT, and the regression that motivated it: a label nobody
+    # recorded was typed by a person and must survive. This clobbered a
+    # tab named "Reviewer" back to its session's "home" in real use.
     : > "$CS_TMP/calls.log"
     cs_label "Reviewer"
-    rm -f /tmp/claude-statusline-tabcheck-utcs
+    rm -f /tmp/claude-tabname-w1-t9 /tmp/claude-statusline-tabcheck-utcs
     cs_run beta
     run_test "claude-statusline: leaves a hand-named tab alone" \
         "! grep -q 'tab rename' '$CS_TMP/calls.log'"
 
-    # THE KNOWN LIMIT, pinned deliberately rather than left to be
-    # rediscovered: claude-name-session omits "/branch" on main, master,
-    # trunk and outside git, so a machine name from a default branch is
-    # slash-free and indistinguishable from a hand-typed one. It is NOT
-    # reclaimed. Under-reclaiming leaves a stale label — the behaviour
-    # that predates this feature — which is the safe direction.
+    # A human name is safe even when it LOOKS machine-made — the old
+    # shape rule reclaimed anything containing a slash.
     : > "$CS_TMP/calls.log"
-    cs_label "herddeck"
-    rm -f /tmp/claude-statusline-tabcheck-utcs
+    cs_label "notes/todo"
+    rm -f /tmp/claude-tabname-w1-t9 /tmp/claude-statusline-tabcheck-utcs
     cs_run beta
-    run_test "claude-statusline: a slash-free machine name is left alone (known limit)" \
+    run_test "claude-statusline: a hand-named tab with a slash is still safe" \
         "! grep -q 'tab rename' '$CS_TMP/calls.log'"
+
+    # A rename must RECORD what it set, or the next session sees an
+    # unrecorded label and treats this session's own name as hand-typed.
+    # Own scenario: the test above deliberately suppresses the rename.
+    : > "$CS_TMP/calls.log"
+    cs_label "9"
+    rm -f /tmp/claude-tabname-w1-t9 /tmp/claude-statusline-tabcheck-utcs
+    cs_run beta
+    run_test "claude-statusline: a rename records the label it set" \
+        "[ \"\$(cat /tmp/claude-tabname-w1-t9 2>/dev/null)\" = beta ]"
 
     # ...and the check runs at most once a minute, or it degrades into a
     # socket call every 5s. touch (not elapsed wall-clock) decides
@@ -829,7 +846,7 @@ CS_STUB
     cs_run beta
     run_test "claude-statusline: drift check is throttled to once a minute" \
         "[ ! -s '$CS_TMP/calls.log' ]"
-    rm -rf "$CS_TMP" /tmp/claude-statusline-name-utcs /tmp/claude-statusline-tabcheck-utcs
+    rm -rf "$CS_TMP" /tmp/claude-statusline-name-utcs /tmp/claude-statusline-tabcheck-utcs /tmp/claude-tabname-w1-t9
 fi
 
 # gitleaks pre-commit engine: same invocation the yadm hook uses, against

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -778,26 +778,41 @@ CS_STUB
     # it is allowed to happen here.
     run_test "claude-statusline: an unchanged session name renames nothing" \
         "! grep -q 'tab rename' '$CS_TMP/calls.log'"
+    # Count, not presence: over-firing is the exact thing these tests
+    # exist to catch, and grep -q passes just as happily on five renames.
     cs_run beta
     run_test "claude-statusline: a /rename propagates to the herdr tab" \
-        "grep -q 'tab rename w1:t9 beta' '$CS_TMP/calls.log'"
+        "[ \"\$(grep -c 'tab rename w1:t9 beta' '$CS_TMP/calls.log')\" -eq 1 ]"
 
     # Drift repair: HERDR_TAB_ID is inherited from the launching pane, so
     # a session working elsewhere can rename a tab it does not own. The
     # session name has NOT changed here, so name-comparison alone can
-    # never notice — only re-reading the tab's real label can.
+    # never notice — only re-reading the tab's real label can. A slash
+    # marks the "project/branch" shape claude-name-session produces.
     : > "$CS_TMP/calls.log"
-    cs_label "stolen-by-another-agent"
+    cs_label "herddeck/feat/some-branch"
     rm -f /tmp/claude-statusline-tabcheck-utcs   # force the check to be due
     cs_run beta
-    run_test "claude-statusline: repairs a tab renamed by someone else" \
-        "grep -q 'tab rename w1:t9 beta' '$CS_TMP/calls.log'"
+    run_test "claude-statusline: repairs a tab renamed by another session" \
+        "[ \"\$(grep -c 'tab rename w1:t9 beta' '$CS_TMP/calls.log')\" -eq 1 ]"
 
-    # ...but only once a minute. The stamp is fresh from the run above,
-    # so a second hijack inside the window must NOT trigger another
-    # query — otherwise the check degrades into a socket call every 5s.
+    # THE LIMIT ON THAT REPAIR. A hand-named tab has no slash and must
+    # survive, or mirroring makes manual names impossible to keep — this
+    # regressed live, clobbering a tab named "Reviewer" back to its
+    # session's "home".
     : > "$CS_TMP/calls.log"
-    cs_label "stolen-again"
+    cs_label "Reviewer"
+    rm -f /tmp/claude-statusline-tabcheck-utcs
+    cs_run beta
+    run_test "claude-statusline: leaves a hand-named tab alone" \
+        "! grep -q 'tab rename' '$CS_TMP/calls.log'"
+
+    # ...and the check runs at most once a minute, or it degrades into a
+    # socket call every 5s. touch (not elapsed wall-clock) decides
+    # "not due", so a slow or suspended suite cannot flake this.
+    : > "$CS_TMP/calls.log"
+    cs_label "herddeck/feat/some-branch"
+    touch /tmp/claude-statusline-tabcheck-utcs
     cs_run beta
     run_test "claude-statusline: drift check is throttled to once a minute" \
         "[ ! -s '$CS_TMP/calls.log' ]"


### PR DESCRIPTION
Found by Nick live: he renamed this session to `Dotfiles` and the herdr tab stayed labelled `herddeck/feat/per-model-weekly` — another repo's branch. Renaming again did nothing at all.

## Two causes, one of them a design flaw in #84

**How the tab got a foreign name:** `HERDR_TAB_ID` is inherited from the launching pane, so a session started from one pane while working in another directory renames a tab it does not own.

**Why it could never self-correct:** the mirror compared the session name against a cache of what that *session* was last called — never against what the *tab* is actually labelled. Once they diverge, renaming back to the same value reads as "no change" and does nothing. Verified against the live cache: `/tmp/claude-statusline-name-…` already said `Dotfiles` while the tab said otherwise. Last writer wins, permanently.

## Fix

Re-read the tab's real label and correct drift — but **at most once a minute**. The statusline runs every `refreshInterval` (5s) and the check costs a socket round-trip, while the drift itself is cosmetic. A separate stamp file carries the duty cycle, because the name cache is only written on change and its mtime would make the check fire every tick.

Default output is byte-identical to before (old and new run in the same second, 654 bytes).

## The test change is the more interesting half

The existing tests asserted *no herdr call at all* for the unchanged-name case. The drift check is a **read**, and a legitimate one — so that assertion made the suite **flaky**: it passed when the throttle stamp happened to be fresh and failed once it aged past a minute. I hit exactly that, two failures then a pass with no code change in between, which is how the interaction surfaced.

Assertions now test for the absence of a tab **rename** rather than the absence of any call, which is what they actually meant, and both cache files are cleared up front so the outcome no longer depends on how recently the suite last ran.

Two new tests pin the behaviour: the stub answers `tab list` from a fixture, so one hijacks the tab label while leaving the session name unchanged and asserts the repair fires — the case name-comparison can never detect — and the next asserts a second hijack inside the same minute does **not** fire, so the throttle is pinned rather than silently degrading into a socket call every 5 seconds.

Suite 136/136, three consecutive runs identical.