### PR TITLE
fix(claude): warn on an orphaned herdr hook entry

### DIFF
--- a/.local/bin/claude-settings-sync
+++ b/.local/bin/claude-settings-sync
@@ -121,6 +121,24 @@ ensure_herdr_integration() {
     command -v herdr >/dev/null 2>&1 || return 0
     if jq -e '[.. | .command? // empty] | any(test("herdr-agent-state"))' \
         "$settings" >/dev/null 2>&1; then
+        # Entry present but its script gone — Claude Code then runs a
+        # SessionStart hook pointing at nothing and exits 127 every
+        # session. Reachable by restoring a settings backup onto a
+        # machine that has not run the integration, or by clearing
+        # ~/.claude/hooks.
+        # Deliberately NOT auto-repaired: regenerating the script means
+        # running the installer, and if the entry was hand-edited (the
+        # $HOME rewrite this repo's checklist prescribes) the installer
+        # does not recognise it and appends a DUPLICATE, so the hook
+        # fires twice per session. There is no automatic action that is
+        # both correct and non-destructive here, so say so and stop.
+        # Relative to the settings file, not $HOME: everything else here
+        # honours CLAUDE_SETTINGS, and a hardcoded path made this check
+        # silently inspect the real machine while testing a sandbox.
+        if [ ! -f "$(dirname "$settings")/hooks/herdr-agent-state.sh" ]; then
+            echo "claude-settings-sync: settings reference herdr-agent-state.sh but the script is missing." >&2
+            echo "  Run: herdr integration install claude   (then check for a DUPLICATE SessionStart entry)" >&2
+        fi
         return 0
     fi
     local err

--- a/docs/upgrade-watch.md
+++ b/docs/upgrade-watch.md
@@ -76,6 +76,28 @@ maintenance.
    macOS so the script falls back to `/bin/ps -o tty=`. If an
    upgrade changes any of these, the keybinding goes dark or the
    toast fallback stops firing.
+   **Open follow-ups on the herdr tab/identity work** (2026-08-08, all
+   deliberately deferred, none urgent):
+   - *Verify the tab, don't trust it.* `HERDR_TAB_ID` is injected at
+     pane spawn and is never updated, so it is wrong after `pane move`
+     and is inherited by anything launched from that pane. Two sessions
+     that both think they own a tab still alternate once a minute.
+     Buildable on 0.8.0: intersect this process's parent chain with each
+     pane's `shell_pid` + foreground pids from `pane process-info` —
+     exactly one pane matches. Cache per session, not per tick.
+   - *Upstream FR:* `tab.rename` takes `{tab_id, label}` with no source
+     field, so programmatic renames are indistinguishable from typed
+     ones and cannot be arbitrated. Every tab-rename plugin in the
+     ecosystem reinvents the same state file, and so do we. Ask for a
+     `source` on `tab.rename`, matching `pane.report_metadata`.
+     Second FR: for an unnamed tab, `label` (positional, `tab_idx + 1`)
+     and `number` (monotonic) in the SAME response disagree after any
+     tab close.
+   - *herdr installer idempotency* (owned by the HerdDeck session): it
+     matches its existing install on the full command string, so the
+     `$HOME` rewrite this repo prescribes reads as absent and it appends
+     a duplicate.
+
    It also reads `herdr pane get <id>` →
    `.result.pane.agent_session.value` to select the transcript
    belonging to the pane you pressed in. Renaming that field only

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -710,6 +710,17 @@ CCL_HERDR2
     run_test "claude-copy-last falls back to newest file without a pane id" \
         "[ \"\$(bash -c \"cd '$CCL_TMP/work' && PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/projects' '$HOME/.local/bin/claude-copy-last'\")\" = 'OTHER PANE' ]"
 
+    # Entry present + hook script gone = exit 127 every session. Warn,
+    # never auto-repair: regenerating means running herdr's installer,
+    # which does not recognise a hand-edited entry and would append a
+    # DUPLICATE. Assert the warning fires AND that nothing was written.
+    printf '{"hooks":{"SessionStart":[{"matcher":"*","hooks":[{"command":"bash \\"$HOME/.claude/hooks/herdr-agent-state.sh\\" session","type":"command"}]}]},"statusLine":{"command":"~/.local/bin/claude-statusline","refreshInterval":5,"type":"command"},"theme":"custom:my-theme"}' \
+        > "$CCL_TMP/orphan.json"
+    run_test "claude-settings-sync warns on an orphaned herdr hook entry" \
+        "CLAUDE_SETTINGS='$CCL_TMP/orphan.json' '$HOME/.local/bin/claude-settings-sync' 2>&1 |
+         grep -q 'script is missing' &&
+         [ \"\$(jq -r '[.. | .command? // empty] | map(select(test(\"herdr\"))) | length' '$CCL_TMP/orphan.json')\" -eq 1 ]"
+
     # herdr silently DROPS clipboard writes over 192 KiB decoded
     # (ghostty MAX_CLIPBOARD_BYTES) — oversize must skip OSC 52 and
     # toast instead of vanishing.

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -716,10 +716,14 @@ CCL_HERDR2
     # DUPLICATE. Assert the warning fires AND that nothing was written.
     printf '{"hooks":{"SessionStart":[{"matcher":"*","hooks":[{"command":"bash \\"$HOME/.claude/hooks/herdr-agent-state.sh\\" session","type":"command"}]}]},"statusLine":{"command":"~/.local/bin/claude-statusline","refreshInterval":5,"type":"command"},"theme":"custom:my-theme"}' \
         > "$CCL_TMP/orphan.json"
+    # Needs herdr: the check sits behind `command -v herdr`, since the
+    # remedy it prints is a herdr command. CI has no herdr.
+    if command -v herdr >/dev/null 2>&1; then
     run_test "claude-settings-sync warns on an orphaned herdr hook entry" \
         "CLAUDE_SETTINGS='$CCL_TMP/orphan.json' '$HOME/.local/bin/claude-settings-sync' 2>&1 |
          grep -q 'script is missing' &&
          [ \"\$(jq -r '[.. | .command? // empty] | map(select(test(\"herdr\"))) | length' '$CCL_TMP/orphan.json')\" -eq 1 ]"
+    fi
 
     # herdr silently DROPS clipboard writes over 192 KiB decoded
     # (ghostty MAX_CLIPBOARD_BYTES) — oversize must skip OSC 52 and


### PR DESCRIPTION
A `settings.json` entry referencing `herdr-agent-state.sh` while the script is gone makes Claude Code run a SessionStart hook pointing at nothing — **exit 127 every session**. Reachable by restoring a settings backup onto a machine that has not run the integration, so this repo's own advice to keep backups makes it *more* likely.

**Warns rather than repairs, deliberately.** Regenerating the script means running herdr's installer, which matches its existing install on the full command string — so the `$HOME` rewrite the checklist prescribes reads as absent and it appends a **duplicate**, firing the hook twice per session. No automatic action here is both correct and non-destructive, so it names the command and what to check afterwards.

Found while testing: the existence check was hardcoded to `$HOME` while everything else honours `CLAUDE_SETTINGS`, so it inspected the real machine while the test drove a sandbox — and stayed silent. Now resolved relative to the settings file.

Also records the three open follow-ups in `upgrade-watch.md` so they outlive this conversation: verifying `HERDR_TAB_ID` by process ancestry rather than trusting it (buildable on 0.8.0), and two upstream gaps — no `source` on `tab.rename`, and `label`/`number` disagreeing for an unnamed tab after any close.

Suite 141/141, markdownlint clean, shellcheck clean.