### PR TITLE
fix(ccl): copy the conversation you are in, not the pane's first session

### DIFF
--- a/.local/bin/claude-copy-last
+++ b/.local/bin/claude-copy-last
@@ -287,6 +287,86 @@ if [ "$have_markers" = 1 ]; then
     last_turn=$(claude_pane_last_user_turn "$transcript")
 fi
 
+# Does the pane actually SHOW the conversation we just selected?
+#
+# Every signal used above answers "where does this session RUN" — the
+# inherited pane id, the process tree, herdr's registration. Claude Code's
+# agent view decouples that from "what does this pane DISPLAY": a
+# background job launched from one pane can be rendered in another, and
+# then all three signals agree with each other and all three are wrong
+# about what you are looking at. Observed live, and it is why this exists.
+#
+# The rendered screen is the one signal derived from the user's attention
+# rather than from process lineage, and HERDR_ACTIVE_PANE_ID — injected by
+# herdr at keypress from the FOCUSED pane, never inherited — is what names
+# it. Measured on the failure that motivated this: of 12 screen lines, 7
+# identified the displayed session uniquely, 5 matched nothing (box-drawing
+# rows and reflowed fragments), and NONE matched the wrong session.
+#
+# STRICTLY A VERIFIER. It cannot change the selection, only describe it, so
+# a bad needle costs a missing warning rather than a wrong answer. The fast
+# path is a plain grep over the selected transcript; the stricter and more
+# expensive search runs only when that fails.
+screen_shows=""
+verify_against_screen() {
+    [ -n "${HERDR_ACTIVE_PANE_ID:-}" ] || return 0
+    local screen needles hit
+    # 40 lines, not 200: measured on a live pane, `recent-unwrapped` with
+    # --lines 200 took 6.8 SECONDS while --lines 40 took 16ms — a
+    # keypress cannot pay the former, and the extra scrollback adds
+    # nothing, since the reply you are looking at is at the bottom.
+    screen=$("$herdr_bin" pane read "$HERDR_ACTIVE_PANE_ID" \
+        --source recent-unwrapped --lines 40 --format text 2>/dev/null) || return 0
+    [ -n "$screen" ] || return 0
+    # Medium-length plain lines only. NOT the longest: a long line is the
+    # one the terminal truncated at the pane width, so it appears nowhere
+    # on disk — picking it was the mistake that made this look unworkable.
+    needles=$(printf '%s\n' "$screen" |
+        sed 's/\033\[[0-9;]*m//g; s/^[[:space:]⏺✻❯│┌└├─]*//; s/[[:space:]]*$//' |
+        grep -vE '^[─━│┌└├┤┬┴┼╭╮╯╰[:space:]]*$' |
+        awk 'length($0) >= 15 && length($0) <= 70' | sort -u | head -8)
+    [ -n "$needles" ] || return 0
+    # All needles in ONE grep pass per file, not one pass per needle:
+    # transcripts run to several MB and the naive loop cost 7.6 seconds on
+    # a keypress. -f turns eight passes into one.
+    local nf
+    nf=$(mktemp "${TMPDIR:-/tmp}/ccl-needles.XXXXXX") || return 0
+    printf '%s\n' "$needles" > "$nf"
+    if grep -qFf "$nf" "$transcript" 2>/dev/null; then
+        rm -f "$nf"
+        return 0   # confirmed: the pane shows what we copied. Say nothing.
+    fi
+    # Nothing on screen appears in what we selected. Find what it does
+    # belong to. grep shortlists cheaply; jq then insists on an ASSISTANT
+    # TEXT BLOCK, because agents relay each other's replies inside tool
+    # arguments, and a whole-file match names every session in the relay
+    # rather than the one that wrote it.
+    while IFS= read -r hit; do
+        [ -n "$hit" ] || continue
+        [ "$hit" = "$transcript" ] && continue
+        # `. as $n` is load-bearing: writing `any($t | index(.))` rebinds
+        # `.` to $t through the pipe, so index() searches the text for
+        # ITSELF and every block matches. That bug named the relayer
+        # instead of the author, and only the relay test caught it.
+        if [ "$(jq -rs --rawfile needles "$nf" '
+                ($needles | split("\n") | map(select(length > 0))) as $ns
+                | [.[] | select(.type == "assistant")
+                   | [.message.content[]? | select(.type == "text") | .text]
+                   | join(" ")]
+                | map(select(. as $t | $ns | any(. as $n | $t | index($n) != null)))
+                | length' "$hit" 2>/dev/null)" -gt 0 ] 2>/dev/null; then
+            screen_shows=${hit##*/}
+            screen_shows=${screen_shows%.jsonl}
+            break
+        fi
+    done <<HITS
+$(grep -lFf "$nf" "$projects_root"/*/*.jsonl 2>/dev/null)
+HITS
+    rm -f "$nf"
+    return 0
+}
+verify_against_screen || true
+
 # Sidechain entries are subagent traffic, not the conversation. One turn
 # can hold several text blocks (status notes between tool calls); each
 # counts as one step of -n, latest first. tail bounds the jq parse.
@@ -419,6 +499,14 @@ provenance() {
     # disagree, and you should be able to see which one you got.
     if [ "${transcript%/*}" != "$proj" ]; then
         extra="$extra, from ${transcript%/*}"
+    fi
+    # The loudest thing this line can say: you are looking at one
+    # conversation and you copied a different one. Nothing else in the
+    # system can notice that, so it goes first and it is not subtle.
+    if [ -n "$screen_shows" ]; then
+        printf '%s (%s) — WARNING: this pane is showing %s' \
+            "$sid_short" "$extra" "${screen_shows%%-*}"
+        return 0
     fi
     age=$(human_age "$last_turn")
     if [ "$no_turn" = 1 ]; then

--- a/.local/bin/claude-copy-last
+++ b/.local/bin/claude-copy-last
@@ -134,13 +134,34 @@ resolve_transcript() {   # $1 session id -> path on stdout, or nothing
     fi
 }
 
+# Membership has a SECOND source, and leaving it behind tier 1 as a
+# fallback was a real hole: markers can be INCOMPLETE. A session whose
+# statusline is not ticking leaves no marker, so a pane holding one
+# marked and one unmarked session looks exactly like a healthy
+# single-session pane — tier 1 ranks its single candidate against
+# nothing, selects it, reports "1 in pane", and every guard passes while
+# the answer is wrong. Observed live: pane w1:p1 held a herdr-registered
+# session with no marker at all.
+#
+# herdr knows that session independently, so its registration JOINS the
+# candidate set instead of waiting behind it. A stale registration costs
+# nothing here: it is ranked like any other candidate, and an old human
+# turn loses.
+herdr_member() {   # $1 pane id -> the session herdr believes is there
+    [ -n "${1:-}" ] || return 0
+    "$herdr_bin" pane get "$1" 2>/dev/null |
+        jq -r '.result.pane.agent_session.value // empty' 2>/dev/null || true
+}
+
 transcript=""
 picked_by=""
 last_turn=""
 cand_count=0
 foreign_count=0
+unreadable_count=0
 no_turn=0
 noturn=""
+seen="|"
 
 if [ "$have_markers" = 1 ] && [ -n "${HERDR_ACTIVE_PANE_ID:-}" ]; then
     best_ts=""
@@ -154,6 +175,10 @@ if [ "$have_markers" = 1 ] && [ -n "${HERDR_ACTIVE_PANE_ID:-}" ]; then
     pane_shell_resolved=0
     while IFS= read -r cand; do
         [ -n "$cand" ] || continue
+        # The two membership sources overlap in the common case; a session
+        # named by both must not be counted twice.
+        case "$seen" in *"|$cand|"*) continue ;; esac
+        seen="$seen$cand|"
         cand_file=$(resolve_transcript "$cand")
         if [ -z "$cand_file" ]; then
             # Janitor: the session's transcript is gone, so its marker is
@@ -182,7 +207,15 @@ if [ "$have_markers" = 1 ] && [ -n "${HERDR_ACTIVE_PANE_ID:-}" ]; then
             fi
         fi
         cand_count=$((cand_count + 1))
-        cand_ts=$(claude_pane_last_user_turn "$cand_file")
+        # A non-zero return means the transcript could not be read, which
+        # is NOT the same as "nobody has spoken here". Ranking the two
+        # alike would let an unreadable candidate lose silently to a
+        # readable one and still print a confident age for the wrong
+        # session, so it is counted and surfaced instead.
+        if ! cand_ts=$(claude_pane_last_user_turn "$cand_file"); then
+            unreadable_count=$((unreadable_count + 1))
+            continue
+        fi
         # ISO-8601 UTC sorts correctly as a plain string, so no date
         # parsing is needed to rank candidates.
         if [ -n "$cand_ts" ]; then
@@ -200,7 +233,7 @@ if [ "$have_markers" = 1 ] && [ -n "${HERDR_ACTIVE_PANE_ID:-}" ]; then
 "
         fi
     done <<MARKERS
-$(claude_pane_marker_sessions "$HERDR_ACTIVE_PANE_ID")
+$(claude_pane_marker_sessions "$HERDR_ACTIVE_PANE_ID" ; herdr_member "$HERDR_ACTIVE_PANE_ID")
 MARKERS
 
     if [ -z "$transcript" ] && [ -n "$noturn" ]; then
@@ -370,6 +403,12 @@ provenance() {
         # would otherwise corroborate rather than expose.
         if [ "$foreign_count" -gt 0 ]; then
             extra="$extra, $foreign_count rejected"
+        fi
+        # A candidate that could not be read was not ranked, so the
+        # selection below was made on an incomplete comparison. Saying so
+        # is the difference between a confident answer and an honest one.
+        if [ "$unreadable_count" -gt 0 ]; then
+            extra="$extra, $unreadable_count unreadable"
         fi
     fi
     # A pane holds a session whose transcript lives under a different

--- a/.local/bin/claude-copy-last
+++ b/.local/bin/claude-copy-last
@@ -303,10 +303,17 @@ fi
 # identified the displayed session uniquely, 5 matched nothing (box-drawing
 # rows and reflowed fragments), and NONE matched the wrong session.
 #
-# STRICTLY A VERIFIER. It cannot change the selection, only describe it, so
-# a bad needle costs a missing warning rather than a wrong answer. The fast
-# path is a plain grep over the selected transcript; the stricter and more
-# expensive search runs only when that fails.
+# STRICTLY A VERIFIER, AND THIS IS THE PROPERTY THAT MAKES IT SAFE TO SHIP:
+# `screen_shows` is written in exactly one place (here) and read in exactly
+# one place (the provenance line). Nothing below touches $transcript,
+# $picked_by, $msg or $last_turn, every exit is a bare `return 0`, and the
+# call site is `|| true` after selection is already complete. It can append
+# a sentence to what is PRINTED and nothing else. If a future edit ever
+# gives it a say in which transcript is chosen, that guarantee is gone and
+# a bad needle becomes a bad copy — so don't.
+#
+# The fast path is a plain grep over the selected transcript; the stricter
+# and more expensive search runs only when that fails.
 screen_shows=""
 verify_against_screen() {
     [ -n "${HERDR_ACTIVE_PANE_ID:-}" ] || return 0
@@ -332,15 +339,21 @@ verify_against_screen() {
     local nf
     nf=$(mktemp "${TMPDIR:-/tmp}/ccl-needles.XXXXXX") || return 0
     printf '%s\n' "$needles" > "$nf"
+    # THE TWO SIDES ARE DELIBERATELY ASYMMETRIC — do not "tidy" them into
+    # agreement. CONFIRMING greps the selected transcript whole-file with no
+    # type restriction, so a reply that arrived here by relay (as a user
+    # entry, a paste, a tool result) still counts as "the pane shows what we
+    # copied" and we stay quiet. ATTRIBUTING to a DIFFERENT session insists
+    # on an assistant text block, because relayed text appears in every
+    # transcript along the chain and a whole-file match would name the
+    # relayer instead of the author. Loose to stay silent, strict to accuse.
     if grep -qFf "$nf" "$transcript" 2>/dev/null; then
         rm -f "$nf"
         return 0   # confirmed: the pane shows what we copied. Say nothing.
     fi
     # Nothing on screen appears in what we selected. Find what it does
-    # belong to. grep shortlists cheaply; jq then insists on an ASSISTANT
-    # TEXT BLOCK, because agents relay each other's replies inside tool
-    # arguments, and a whole-file match names every session in the relay
-    # rather than the one that wrote it.
+    # belong to. grep shortlists cheaply; jq then applies the strict test.
+    local matches=""
     while IFS= read -r hit; do
         [ -n "$hit" ] || continue
         [ "$hit" = "$transcript" ] && continue
@@ -355,14 +368,23 @@ verify_against_screen() {
                    | join(" ")]
                 | map(select(. as $t | $ns | any(. as $n | $t | index($n) != null)))
                 | length' "$hit" 2>/dev/null)" -gt 0 ] 2>/dev/null; then
-            screen_shows=${hit##*/}
-            screen_shows=${screen_shows%.jsonl}
-            break
+            hit=${hit##*/}
+            matches="$matches${hit%.jsonl} "
         fi
     done <<HITS
 $(grep -lFf "$nf" "$projects_root"/*/*.jsonl 2>/dev/null)
 HITS
     rm -f "$nf"
+    # Report ONLY when the evidence names exactly one session. Breaking on
+    # the first match would have let glob order decide an ambiguity and
+    # present it as definite — silent, arbitrary and stable, which is the
+    # precise pattern the rest of this file exists to remove. Two matches
+    # means the screen does not identify anything, so say nothing.
+    # shellcheck disable=SC2086  # session ids are uuids; word splitting is the point
+    set -- $matches
+    if [ $# -eq 1 ]; then
+        screen_shows=$1
+    fi
     return 0
 }
 verify_against_screen || true
@@ -503,8 +525,16 @@ provenance() {
     # The loudest thing this line can say: you are looking at one
     # conversation and you copied a different one. Nothing else in the
     # system can notice that, so it goes first and it is not subtle.
+    #
+    # It says "on-screen text belongs to X", not "this pane is showing X",
+    # because that is what was actually established. The two coincide for
+    # the agent view this was built for, but a pane that merely renders
+    # another session's reply — a cat, a pager, a paste — would make the
+    # stronger claim false while the narrower one stays true. A warning
+    # that overstates gets distrusted, and this one has to be believed on
+    # the day it fires.
     if [ -n "$screen_shows" ]; then
-        printf '%s (%s) — WARNING: this pane is showing %s' \
+        printf '%s (%s) — WARNING: on-screen text belongs to %s' \
             "$sid_short" "$extra" "${screen_shows%%-*}"
         return 0
     fi

--- a/.local/bin/claude-copy-last
+++ b/.local/bin/claude-copy-last
@@ -96,32 +96,162 @@ if [ -z "$proj" ]; then
     exit 1
 fi
 
-# Which transcript belongs to the pane you pressed the key in?
-# Concurrent agents in one directory share a slug dir, so "newest file"
-# copies whichever session wrote last — with two Claude panes both in
-# $HOME, pressing in one reliably pasted the other's reply.
-# herdr answers this directly: it tracks each pane's Claude session id
-# and transcripts are named <session-id>.jsonl. Ask it first, fall back
-# to mtime for plain shells, tmux, or panes whose agent never reported
-# an identity (herdr leaves agent_session unset there).
+# Which transcript belongs to the pane you pressed the key in? Three
+# tiers, most authoritative first. Each falls through to the next, so a
+# missing tier degrades to the previous behaviour rather than to a wrong
+# answer.
+#
+# 1. PANE MEMBERSHIP + LAST USER TURN. The statusline records one marker
+#    per (pane, session), so this can enumerate EVERY session in the
+#    pane — which herdr cannot: it keeps at most one and refuses to
+#    replace it for a newly started session, so a background job (which
+#    inherits HERDR_PANE_ID) is invisible to it. Among a pane's
+#    sessions, the conversation you are in is the one you spoke to most
+#    recently. See .local/lib/claude-pane-marker.sh for the measurements.
+# 2. HERDR'S REGISTRATION. Correct whenever a pane holds a single
+#    session, which is the common case, and it is the only tier that
+#    works for a session whose statusline never ran.
+# 3. MTIME. Plain shells, tmux, and panes with neither of the above.
+#    Copies whichever session in this directory wrote last — which is
+#    exactly the failure tiers 1 and 2 exist to prevent.
+if [ -r "$HOME/.local/lib/claude-pane-marker.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOME/.local/lib/claude-pane-marker.sh"
+    have_markers=1
+else
+    have_markers=0
+fi
+
+resolve_transcript() {   # $1 session id -> path on stdout, or nothing
+    [ -n "${1:-}" ] || return 0
+    if [ -f "$proj/$1.jsonl" ]; then
+        printf '%s' "$proj/$1.jsonl"
+    else
+        # cwd walk landed on a different project dir than the one claude
+        # was launched from — the id is authoritative, take it wherever
+        # it lives
+        find "$projects_root" -maxdepth 2 -name "$1.jsonl" -print -quit 2>/dev/null
+    fi
+}
+
 transcript=""
-if [ -n "${HERDR_ACTIVE_PANE_ID:-}" ]; then
-    sid=$("$herdr_bin" pane get "$HERDR_ACTIVE_PANE_ID" 2>/dev/null |
-        jq -r '.result.pane.agent_session.value // empty' 2>/dev/null) || sid=""
-    if [ -n "$sid" ]; then
-        if [ -f "$proj/$sid.jsonl" ]; then
-            transcript="$proj/$sid.jsonl"
+picked_by=""
+last_turn=""
+cand_count=0
+foreign_count=0
+no_turn=0
+noturn=""
+
+if [ "$have_markers" = 1 ] && [ -n "${HERDR_ACTIVE_PANE_ID:-}" ]; then
+    best_ts=""
+    # The pane's shell is used below as an INDEPENDENT witness that a
+    # marker is telling the truth — see the lib for why nothing else can
+    # be. Resolved LAZILY: a pane with no markers, or with none carrying a
+    # pid, must make no herdr call at all. (The suite caught this: an
+    # unconditional call here tripped a test asserting that the oversize
+    # path touches no pane tty.)
+    pane_shell=""
+    pane_shell_resolved=0
+    while IFS= read -r cand; do
+        [ -n "$cand" ] || continue
+        cand_file=$(resolve_transcript "$cand")
+        if [ -z "$cand_file" ]; then
+            # Janitor: the session's transcript is gone, so its marker is
+            # dead weight. Reaping only what we look at keeps this
+            # O(candidates) rather than a directory sweep on every copy;
+            # another pane's stale markers are reaped by its own copies.
+            rm -f "$(claude_pane_marker_file "$HERDR_ACTIVE_PANE_ID" "$cand")" 2>/dev/null || true
+            continue
+        fi
+        # Drop a candidate only on a CONTRADICTION: its pid is alive and
+        # demonstrably not in this pane's process tree. A dead pid, an
+        # unrecorded pid, or an unresolvable pane shell all prove nothing,
+        # so the candidate is kept — this can only ever remove a claim
+        # that is provably false, never one that is merely unverified.
+        cand_pid=$(claude_pane_marker_pid "$HERDR_ACTIVE_PANE_ID" "$cand")
+        if [ -n "$cand_pid" ] && kill -0 "$cand_pid" 2>/dev/null; then
+            if [ "$pane_shell_resolved" = 0 ]; then
+                pane_shell=$("$herdr_bin" pane process-info --pane "$HERDR_ACTIVE_PANE_ID" 2>/dev/null |
+                    jq -r '.result.process_info.shell_pid // empty' 2>/dev/null) || pane_shell=""
+                pane_shell_resolved=1
+            fi
+            if [ -n "$pane_shell" ] &&
+               ! claude_pane_pid_descends_from "$cand_pid" "$pane_shell"; then
+                foreign_count=$((foreign_count + 1))
+                continue
+            fi
+        fi
+        cand_count=$((cand_count + 1))
+        cand_ts=$(claude_pane_last_user_turn "$cand_file")
+        # ISO-8601 UTC sorts correctly as a plain string, so no date
+        # parsing is needed to rank candidates.
+        if [ -n "$cand_ts" ]; then
+            if [ -z "$best_ts" ] || [ "$cand_ts" \> "$best_ts" ]; then
+                best_ts="$cand_ts"
+                transcript="$cand_file"
+                picked_by=pane
+            fi
         else
-            # cwd walk landed on a different project dir than the one
-            # claude was launched from — the id is authoritative, so
-            # take it wherever it lives
-            transcript=$(find "$projects_root" -maxdepth 2 -name "$sid.jsonl" -print -quit 2>/dev/null)
+            # A session nobody has ever spoken to — driven only by
+            # automation, or newly started in a reused pane. Held aside:
+            # ANY candidate with a human turn is strictly more evidence
+            # and must win, so these are only consulted if none has one.
+            noturn="$noturn$cand_file
+"
+        fi
+    done <<MARKERS
+$(claude_pane_marker_sessions "$HERDR_ACTIVE_PANE_ID")
+MARKERS
+
+    if [ -z "$transcript" ] && [ -n "$noturn" ]; then
+        # Every candidate is unspoken-to, so there is no evidence to rank
+        # on. Do NOT let glob order decide: it is UUID-lexicographic,
+        # which is arbitrary AND stable — it would pick the same wrong one
+        # every time with nothing indicating a choice was made, which is
+        # the silent-arbitrary pattern this whole mechanism exists to
+        # remove. Consult herdr instead: its registration is real evidence
+        # (first agent detected in the pane), and it is already tier 2, so
+        # this reuses the ladder rather than inventing a fourth rule.
+        no_turn=1
+        picked_by=pane
+        sid=$("$herdr_bin" pane get "$HERDR_ACTIVE_PANE_ID" 2>/dev/null |
+            jq -r '.result.pane.agent_session.value // empty' 2>/dev/null) || sid=""
+        if [ -n "$sid" ]; then
+            while IFS= read -r nf; do
+                [ -n "$nf" ] || continue
+                case "$nf" in */"$sid".jsonl) transcript="$nf" ;; esac
+            done <<NOTURN
+$noturn
+NOTURN
+        fi
+        if [ -z "$transcript" ]; then
+            # herdr names none of them. Fall back to "the one that is at
+            # least doing something" — still arbitrary in principle, but
+            # tied to activity rather than to filename entropy.
+            # shellcheck disable=SC2012  # uuid names, no odd characters
+            transcript=$(printf '%s' "$noturn" | sed '/^$/d' | tr '\n' '\0' |
+                xargs -0 ls -t 2>/dev/null | head -1)
         fi
     fi
 fi
+
+if [ -z "$transcript" ] && [ -n "${HERDR_ACTIVE_PANE_ID:-}" ]; then
+    sid=$("$herdr_bin" pane get "$HERDR_ACTIVE_PANE_ID" 2>/dev/null |
+        jq -r '.result.pane.agent_session.value // empty' 2>/dev/null) || sid=""
+    transcript=$(resolve_transcript "$sid")
+    if [ -n "$transcript" ]; then
+        picked_by=herdr
+    fi
+fi
+
 if [ -z "$transcript" ]; then
     # shellcheck disable=SC2012  # slug dirs + uuid names, no odd characters
     transcript=$(ls -t "$proj"/*.jsonl | head -1)
+    picked_by=mtime
+fi
+
+if [ "$have_markers" = 1 ]; then
+    last_turn=$(claude_pane_last_user_turn "$transcript")
 fi
 
 # Sidechain entries are subagent traffic, not the conversation. One turn
@@ -202,11 +332,75 @@ osc52_to_pane() {
     fi
 }
 
+# Say what was actually copied. Every failure this tool has had cost an
+# hour for the same reason: the copy SUCCEEDED and reported nothing, so
+# there was no way to see it had used the wrong keymap, the wrong
+# machine's clipboard, or the wrong session. The tier matters too —
+# `mtime` has already served one pane another pane's conversation
+# silently, so it is worth naming when it is the one that decided.
+human_age() {   # $1 ISO-8601 -> "45s" / "12m" / "3h07m" / "2d", or nothing
+    [ -n "${1:-}" ] || return 0
+    local secs
+    secs=$(jq -rn --arg ts "$1" '
+        ($ts | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $t
+        | (now - $t) | floor' 2>/dev/null) || return 0
+    case "$secs" in '' | *[!0-9-]*) return 0 ;; esac
+    if [ "$secs" -lt 0 ]; then secs=0; fi
+    if [ "$secs" -lt 60 ]; then printf '%ss' "$secs"
+    elif [ "$secs" -lt 3600 ]; then printf '%sm' "$((secs / 60))"
+    elif [ "$secs" -lt 86400 ]; then printf '%sh%02dm' "$((secs / 3600))" "$(((secs % 3600) / 60))"
+    else printf '%sd' "$((secs / 86400))"
+    fi
+}
+
+provenance() {
+    local sid_short age extra
+    sid_short=${transcript##*/}
+    sid_short=${sid_short%.jsonl}
+    sid_short=${sid_short%%-*}
+    extra="$picked_by"
+    # Candidate count is instrumentation, not decoration: if this bug
+    # ever recurs it says immediately whether the pane's membership set
+    # was wrong or its ranking was.
+    if [ "$picked_by" = pane ]; then
+        extra="$picked_by, $cand_count in pane"
+        # A marker that named this pane but whose process lives elsewhere.
+        # Worth saying out loud: it means something is claiming a pane it
+        # does not occupy, which is the one failure the candidate count
+        # would otherwise corroborate rather than expose.
+        if [ "$foreign_count" -gt 0 ]; then
+            extra="$extra, $foreign_count rejected"
+        fi
+    fi
+    # A pane holds a session whose transcript lives under a different
+    # project directory whenever something was launched from it with
+    # another cwd — a background job, most often. That is genuinely this
+    # pane's conversation, so it is the right answer, but it is the one
+    # case where "this pane's conversation" and "the project I am in"
+    # disagree, and you should be able to see which one you got.
+    if [ "${transcript%/*}" != "$proj" ]; then
+        extra="$extra, from ${transcript%/*}"
+    fi
+    age=$(human_age "$last_turn")
+    if [ "$no_turn" = 1 ]; then
+        # Say it outright: nothing in this pane has ever been spoken to,
+        # so the choice below was made on weaker evidence than usual.
+        printf '%s (%s) · no human turn in this pane' "$sid_short" "$extra"
+    elif [ -n "$age" ]; then
+        printf '%s (%s) · you last spoke %s ago' "$sid_short" "$extra" "$age"
+    else
+        printf '%s (%s)' "$sid_short" "$extra"
+    fi
+}
+
 if [ "$copy" = always ]; then
     # clip failure must not gate OSC 52 (stdio is nulled — toast it):
     # on a clipboard-tool-less server the pane delivery still works
     printf '%s' "$msg" | clip || notify "server clipboard tool failed — pane OSC 52 only"
     osc52_to_pane
+    # Success toast: under a keybinding this is the ONLY channel, and a
+    # silent success is what let a wrong-session copy go unnoticed.
+    notify "copied ${#msg} chars — $(provenance)"
 elif [ -t 1 ]; then
     printf '%s' "$msg" | clip
     # Also OSC 52 through the controlling terminal: reaches the LOCAL
@@ -216,7 +410,7 @@ elif [ -t 1 ]; then
         osc52_seq > /dev/tty || true
     fi
     first_line=$(printf '%s' "$msg" | head -n 1)
-    printf 'copied %s chars from %s\n' "${#msg}" "${transcript##*/}"
+    printf 'copied %s chars from %s\n' "${#msg}" "$(provenance)"
     printf '%.100s…\n' "$first_line"
 else
     printf '%s\n' "$msg"

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -113,6 +113,13 @@ if [ -n "${HERDR_PANE_ID:-}" ] && [ -r "$HOME/.local/lib/claude-pane-marker.sh" 
     # shellcheck source=/dev/null
     . "$HOME/.local/lib/claude-pane-marker.sh"
     claude_pane_marker_write "$HERDR_PANE_ID" "$SESSION_ID" || true
+    # Reap markers for panes that no longer exist. claude-copy-last's
+    # janitor only ever visits its own pane's key, so a closed pane's
+    # markers are never looked at again and would accumulate forever.
+    # Self-throttled to once an hour inside the function; backgrounded so
+    # a slow directory walk can never delay the prompt.
+    ( claude_pane_marker_sweep "${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}" \
+        >/dev/null 2>&1 || true ) &
 fi
 
 # Feed HerdDeck's Stream Deck context donut with the percentage we just

--- a/.local/bin/claude-statusline
+++ b/.local/bin/claude-statusline
@@ -97,6 +97,24 @@ PCT=${PCT_RAW%.*}
 FIVE_H_INT=${FIVE_H%.*}
 SEVEN_D_INT=${SEVEN_D%.*}
 
+# Record that this session lives in this pane, so claude-copy-last can
+# enumerate a pane's sessions. herdr tracks only ONE per pane and will not
+# replace it for a newly started one, so a background job — which inherits
+# HERDR_PANE_ID — is invisible to it; see .local/lib/claude-pane-marker.sh
+# for the measurements. The statusline is the right writer precisely because
+# it runs for EVERY live session, which is useless for deciding which
+# session you are talking to but is exactly the enumeration we need.
+#
+# Deliberately NOT behind SHOW_HERDR — that gates herdr API traffic and this
+# is a local file with no herdr call in it — and NOT behind the tab-drift
+# throttle below. A writer hidden behind either was among the suspects when
+# an earlier attempt at this failed for reasons never diagnosed.
+if [ -n "${HERDR_PANE_ID:-}" ] && [ -r "$HOME/.local/lib/claude-pane-marker.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOME/.local/lib/claude-pane-marker.sh"
+    claude_pane_marker_write "$HERDR_PANE_ID" "$SESSION_ID" || true
+fi
+
 # Feed HerdDeck's Stream Deck context donut with the percentage we just
 # parsed. Claude Code is the only thing that knows it, and the
 # statusline is the only place it surfaces — so the donut has to be fed

--- a/.local/lib/claude-pane-marker.sh
+++ b/.local/lib/claude-pane-marker.sh
@@ -143,13 +143,67 @@ claude_pane_marker_pid() {   # $1 pane id, $2 session id -> pid, or nothing
     sed -n 's/^pid=\([0-9][0-9]*\)$/\1/p' "$_cpm_file" 2>/dev/null | head -n 1 || true
 }
 
+# A session id read out of a filename is UNVALIDATED INPUT, and it is used
+# downstream in two glob contexts (`find -name "$id.jsonl"` and a `case`
+# pattern). A marker named `w1-p3--*` would yield the id `*`, and
+# `-name "*.jsonl"` then matches the first transcript found anywhere under
+# the projects root — a wrong answer, silently, from a file this design has
+# declared trusted.
+#
+# Only the same user can create such a file, so this is not a privilege
+# boundary. It is worth the line anyway: the test suite writes into this
+# directory, and "same user" has already left a phantom marker in a live
+# pane once. Trusting the directory's PERMISSIONS says nothing about its
+# CONTENTS.
 claude_pane_marker_sessions() {   # $1 pane id -> session ids, one per line
     _cpm_dir=$(claude_pane_marker_dir)
     _cpm_key=$(claude_pane_marker_key "${1:-}")
     [ -n "$_cpm_key" ] || return 0
     for _cpm_f in "$_cpm_dir/$_cpm_key"--*; do
         [ -e "$_cpm_f" ] || continue
-        printf '%s\n' "${_cpm_f##*--}"
+        _cpm_sid=${_cpm_f##*--}
+        case "$_cpm_sid" in
+            '' | *[!0-9A-Za-z_-]*) continue ;;
+        esac
+        printf '%s\n' "$_cpm_sid"
+    done
+}
+
+# Reap markers for panes that no longer exist. The per-copy janitor in
+# claude-copy-last only ever visits its OWN pane's key, so when a pane is
+# closed nothing reads those markers again and they persist forever — with
+# no TTL by design, the directory would grow monotonically with every
+# (pane, session) pair the machine has ever seen. Tiny files, so this is
+# hygiene rather than a bug, but it is unbounded and nothing would notice.
+#
+# The condition is deliberately BOTH: pid dead AND transcript gone. A dead
+# session whose transcript survives is still the correct answer for its pane
+# until someone speaks there again, so its membership must not be reaped.
+claude_pane_marker_sweep() {   # $1 projects root
+    _cpm_dir=$(claude_pane_marker_dir)
+    [ -d "$_cpm_dir" ] || return 0
+    _cpm_root="${1:-$HOME/.claude/projects}"
+    # Once an hour at most: this walks the directory, and the statusline
+    # that calls it runs every few seconds for every live session.
+    _cpm_stamp="$_cpm_dir/.swept"
+    if [ -e "$_cpm_stamp" ] && [ -z "$(find "$_cpm_stamp" -mmin +60 2>/dev/null)" ]; then
+        return 0
+    fi
+    : > "$_cpm_stamp" 2>/dev/null || return 0
+    for _cpm_f in "$_cpm_dir"/*--*; do
+        [ -e "$_cpm_f" ] || continue
+        _cpm_sid=${_cpm_f##*--}
+        case "$_cpm_sid" in
+            '' | *[!0-9A-Za-z_-]*) continue ;;
+        esac
+        _cpm_pid=$(sed -n 's/^pid=\([0-9][0-9]*\)$/\1/p' "$_cpm_f" 2>/dev/null | head -n 1)
+        if [ -n "$_cpm_pid" ] && kill -0 "$_cpm_pid" 2>/dev/null; then
+            continue
+        fi
+        if [ -n "$(find "$_cpm_root" -maxdepth 2 -name "$_cpm_sid.jsonl" -print -quit 2>/dev/null)" ]; then
+            continue
+        fi
+        rm -f "$_cpm_f" 2>/dev/null || true
     done
 }
 
@@ -188,16 +242,35 @@ claude_pane_marker_sessions() {   # $1 pane id -> session ids, one per line
 # silently, and wrongly.
 #
 # Emits an ISO-8601 UTC timestamp, which sorts correctly as a plain string,
-# so callers need no date parsing. Emits NOTHING when there is no human turn
-# — callers must treat that as "unknown", never as epoch zero.
+# so callers need no date parsing.
+#
+# THE RETURN CODE IS PART OF THE CONTRACT. Empty output means "this session
+# has no human turn". A NON-ZERO RETURN means "I could not read this
+# transcript", which is a different thing and must not be ranked as though
+# it were the first. Collapsing the two would let an unreadable candidate —
+# possibly the one with the most recent human turn — lose silently to a
+# readable one, and the caller would print a confident age for the wrong
+# session. Ranking on "unknown" is exactly as wrong as ranking on epoch
+# zero; it merely fails in the other direction.
+#
+# Timestamps are normalised to always carry a fractional part, because the
+# comparison is a string comparison: '2026-01-01T00:00:00Z' and
+# '2026-01-01T00:00:00.500Z' at the same second would otherwise sort
+# backwards ('.' is below 'Z' in ASCII). Both forms are known to occur.
+# Normalising keeps the value a valid ISO-8601 instant, so callers can still
+# hand it to a date parser.
 claude_pane_last_user_turn() {   # $1 transcript path
-    [ -f "${1:-}" ] || return 0
-    jq -r '
+    [ -f "${1:-}" ] || return 2
+    _cpm_turns=$(jq -r '
         select(.type == "user"
                and (.isMeta != true)
                and (.isSidechain != true)
                and (.isCompactSummary != true))
         | select(((.message.content | type) == "string")
                  or ([.message.content[]?.type] | any(. != "tool_result")))
-        | .timestamp // empty' "$1" 2>/dev/null | tail -n 1 || true
+        | (.timestamp // empty)
+        | if test("\\.[0-9]+Z$") then . else sub("Z$"; ".000Z") end' \
+        "$1" 2>/dev/null) || return 2
+    printf '%s\n' "$_cpm_turns" | tail -n 1
+    return 0
 }

--- a/.local/lib/claude-pane-marker.sh
+++ b/.local/lib/claude-pane-marker.sh
@@ -1,0 +1,203 @@
+#!/bin/sh
+# claude-pane-marker — pane membership for Claude sessions.
+#
+# Sourced by claude-statusline (the writer) and claude-copy-last (the
+# reader). ONE definition of where markers live, what they are called, and
+# how a conversation is ranked. Two copies of these expressions would be a
+# divergence waiting to happen, and a silent one: a mismatch does not error,
+# it just looks like "there are no markers".
+#
+# WHY THIS EXISTS
+# herdr tracks at most ONE Claude session per pane, and 0.8.0 refuses to
+# replace an existing registration when the new session reports
+# session_start_source "startup" — which is what every new session reports.
+# (Verified against the running server: startup is rejected, resume/compact/
+# clear are accepted, and a rejected write still answers {"type":"ok"}.)
+# So the SECOND session in a pane — most often a background job, which
+# inherits HERDR_PANE_ID from the pane it was launched from — is invisible
+# to herdr forever, and claude-copy-last would copy the first session's
+# transcript perfectly: the wrong conversation. Observed live in two panes
+# at once, each with a foreground session and a background job.
+#
+# WHAT A MARKER IS, AND IS NOT
+# One empty file per (pane, session) pair saying only "this session lives in
+# this pane". It carries NO freshness meaning. Every live session's
+# statusline ticks, so marker mtime separates live from dead — which is not
+# the question anyone is asking. Ordering comes from the last user turn in
+# each transcript instead: it needs no writer, so it cannot go stale, and it
+# cannot be wrong about a session that stopped rendering.
+#
+# WHY NOT /tmp
+# This file decides which conversation reaches your clipboard, so it is
+# trusted input, not an advisory cache. /tmp is world-writable: any local
+# process could pre-create a marker and steer the answer. The other markers
+# this repo writes stay in /tmp because they are advisory — do not "tidy"
+# them back together.
+
+# Override exists for the test suite; nothing else should set it.
+claude_pane_marker_dir() {
+    printf '%s' "${CLAUDE_PANE_MARKER_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/claude-pane}"
+}
+
+# Pane ids contain ':' (w1:p3); session ids are uuids. '--' separates the
+# two halves so the reader can split a filename back apart, and session ids
+# never contain it.
+claude_pane_marker_key() {
+    printf '%s' "$1" | tr -c 'A-Za-z0-9._' '-'
+}
+
+claude_pane_marker_file() {   # $1 pane id, $2 session id
+    printf '%s/%s--%s' "$(claude_pane_marker_dir)" "$(claude_pane_marker_key "$1")" "$2"
+}
+
+# 0700 explicitly: the directory is trusted input, so it must not be
+# group- or world-writable even if the user's umask is loose.
+claude_pane_marker_write() {   # $1 pane id, $2 session id
+    [ -n "${1:-}" ] && [ -n "${2:-}" ] || return 1
+    _cpm_dir=$(claude_pane_marker_dir)
+    if [ ! -d "$_cpm_dir" ]; then
+        # chmod separately rather than `mkdir -m`: with -p, -m applies only
+        # to the deepest directory (SC2174), and the mode here is a security
+        # property, not a preference — it must not depend on that subtlety.
+        mkdir -p "$_cpm_dir" 2>/dev/null || return 1
+        chmod 700 "$_cpm_dir" 2>/dev/null || return 1
+    fi
+    _cpm_file=$(claude_pane_marker_file "$1" "$2")
+    # Membership does not change once true, so the common path is a single
+    # `kill -0` and no write at all. Rewrite only when the marker is
+    # missing, empty (written by an older version), or names a pid that is
+    # gone — that last case makes a marker self-healing across a restart
+    # rather than leaving a permanently unverifiable claim behind.
+    _cpm_pid=$(claude_pane_marker_pid "$1" "$2")
+    if [ -n "$_cpm_pid" ] && kill -0 "$_cpm_pid" 2>/dev/null; then
+        return 0
+    fi
+    _cpm_new=$(claude_pane_session_pid || true)
+    if [ -n "$_cpm_new" ]; then
+        printf 'pid=%s\n' "$_cpm_new" > "$_cpm_file" 2>/dev/null || return 1
+    else
+        # No pid resolvable — still record membership. An unverifiable
+        # marker is worth more than none: it degrades to the behaviour
+        # before pids were recorded, rather than losing the pane entirely.
+        [ -e "$_cpm_file" ] || : > "$_cpm_file" 2>/dev/null || return 1
+    fi
+    return 0
+}
+
+# WHY THE MARKER IS NOT EMPTY
+# A marker's pane key can be correct from the reader's point of view and
+# still be false in fact: HERDR_PANE_ID is INHERITED, so a session running
+# somewhere else can write a marker for a pane it does not occupy. Filtering
+# cannot catch that — the marker names the very pane being read, so it is
+# admitted correctly — and the candidate count corroborates the lie, because
+# "2 in pane" is exactly what a legitimate co-resident pair looks like.
+#
+# Nor can it be caught by re-reading the process's own HERDR_PANE_ID: that
+# is where the marker came from, so the two agree by construction. It needs
+# an INDEPENDENT witness, and there is one — the process tree. Verified on a
+# live pane: both the foreground session and a background job descend from
+# the pane's shell_pid, so ancestry distinguishes a session that really runs
+# in a pane from one that merely inherited its name.
+#
+#   pid 25550 (background job) <- 25530 <- 12409 <- 56402 (-zsh) = shell_pid
+#   pid  4883 (background job) <- 25530 <- 12409 <- 56402 (-zsh) = shell_pid
+#
+# So the marker records the session's pid, which is what makes that check
+# possible at all.
+
+# The statusline is a grandchild of the session process, so walk up to the
+# nearest ancestor that IS claude rather than assuming a fixed depth.
+claude_pane_session_pid() {
+    _cpm_p="${PPID:-}"
+    _cpm_hops=0
+    while [ -n "$_cpm_p" ] && [ "$_cpm_p" != 0 ] && [ "$_cpm_p" != 1 ]; do
+        case $(ps -o comm= -p "$_cpm_p" 2>/dev/null) in
+            *claude) printf '%s' "$_cpm_p"; return 0 ;;
+        esac
+        _cpm_hops=$((_cpm_hops + 1))
+        if [ "$_cpm_hops" -gt 8 ]; then return 1; fi
+        _cpm_p=$(ps -o ppid= -p "$_cpm_p" 2>/dev/null | tr -d ' ')
+    done
+    return 1
+}
+
+# 0 if $1 is $2 or descends from it. Bounded so a cycle or a ps that
+# misbehaves cannot spin.
+claude_pane_pid_descends_from() {   # $1 pid, $2 ancestor pid
+    _cpm_p="${1:-}"
+    _cpm_target="${2:-}"
+    [ -n "$_cpm_p" ] && [ -n "$_cpm_target" ] || return 1
+    _cpm_hops=0
+    while [ -n "$_cpm_p" ] && [ "$_cpm_p" != 0 ] && [ "$_cpm_p" != 1 ]; do
+        if [ "$_cpm_p" = "$_cpm_target" ]; then return 0; fi
+        _cpm_hops=$((_cpm_hops + 1))
+        if [ "$_cpm_hops" -gt 12 ]; then return 1; fi
+        _cpm_p=$(ps -o ppid= -p "$_cpm_p" 2>/dev/null | tr -d ' ')
+    done
+    return 1
+}
+
+claude_pane_marker_pid() {   # $1 pane id, $2 session id -> pid, or nothing
+    _cpm_file=$(claude_pane_marker_file "${1:-}" "${2:-}")
+    [ -f "$_cpm_file" ] || return 0
+    sed -n 's/^pid=\([0-9][0-9]*\)$/\1/p' "$_cpm_file" 2>/dev/null | head -n 1 || true
+}
+
+claude_pane_marker_sessions() {   # $1 pane id -> session ids, one per line
+    _cpm_dir=$(claude_pane_marker_dir)
+    _cpm_key=$(claude_pane_marker_key "${1:-}")
+    [ -n "$_cpm_key" ] || return 0
+    for _cpm_f in "$_cpm_dir/$_cpm_key"--*; do
+        [ -e "$_cpm_f" ] || continue
+        printf '%s\n' "${_cpm_f##*--}"
+    done
+}
+
+# The conversation you are IN is the one you spoke to most recently — not
+# the one most recently WRITTEN. A session can write for hours with no human
+# input: measured on a live pane, a foreground session's transcript was
+# touched three hours after its last human turn while a background job in
+# the same pane had one 44 minutes old. mtime picked the wrong one.
+#
+# Four kinds of entry are type "user" without being you, and each was
+# counted before it was excluded:
+#
+#   tool_result       the bulk of them — 728 of 802 array-content user
+#                     entries in one measured transcript. Ranking on these
+#                     tracks AGENT activity, which is mtime with extra
+#                     steps: naive "last user entry" read 05:17:35Z against
+#                     an actual last human turn of 05:10:41Z.
+#   isCompactSummary  /compact writes a type:"user" entry whose content is a
+#                     STRING and whose isMeta is null, so it passes both a
+#                     shape filter and an isMeta filter. Excluded
+#                     unconditionally because AUTO-compaction fires at an
+#                     unpredictable moment and is not a human acting.
+#   isMeta            system notices.
+#   isSidechain       subagent traffic; a subagent's turn must not decide
+#                     who owns the pane.
+#
+# The shape test is "contains anything that is not a tool_result", not
+# "contains a text block": a human turn can arrive as an array carrying an
+# image or other block, and four such entries exist in one measured
+# transcript. Shape is the wrong discriminator in both directions.
+#
+# Streams rather than slurps, and reads the WHOLE file: extraction wants the
+# recent tail, but ordering wants the last human turn however far back it
+# is. A session whose human spoke once and then ran thousands of tool calls
+# would drop out of a tail window and be ranked as "never spoken to" —
+# silently, and wrongly.
+#
+# Emits an ISO-8601 UTC timestamp, which sorts correctly as a plain string,
+# so callers need no date parsing. Emits NOTHING when there is no human turn
+# — callers must treat that as "unknown", never as epoch zero.
+claude_pane_last_user_turn() {   # $1 transcript path
+    [ -f "${1:-}" ] || return 0
+    jq -r '
+        select(.type == "user"
+               and (.isMeta != true)
+               and (.isSidechain != true)
+               and (.isCompactSummary != true))
+        | select(((.message.content | type) == "string")
+                 or ([.message.content[]?.type] | any(. != "tool_result")))
+        | .timestamp // empty' "$1" 2>/dev/null | tail -n 1 || true
+}

--- a/docs/claude-tooling.md
+++ b/docs/claude-tooling.md
@@ -63,10 +63,11 @@ registration all agree with each other and all three are wrong about what
 you are looking at.
 
 So after choosing, `ccl` checks the pane's rendered screen against what it
-picked. If they disagree it says so:
+picked. If they disagree it says so — narrowly, in the terms it actually
+established, and only when the evidence names exactly one session:
 
 ```text
-copied 333 chars from 3bcaa0fe — WARNING: this pane is showing 8f485a02
+copied 333 chars from 3bcaa0fe — WARNING: on-screen text belongs to 8f485a02
 ```
 
 This is a verifier, never a selector: it cannot change the answer, only

--- a/docs/claude-tooling.md
+++ b/docs/claude-tooling.md
@@ -30,14 +30,43 @@ ccl > notes.md
 
 Bound to `prefix+O` in tmux and `prefix+shift+O` in herdr.
 
-**How it picks the transcript.** Inside herdr it asks which Claude
-session that pane holds and reads exactly that one. This matters when
-several agents share a directory: choosing "the most recently written
-file" pastes the neighbouring pane's reply, which is a confusing way to
-find out your tooling is guessing.
+**How it picks the transcript.** Three tiers, each falling through to
+the next, so a missing tier degrades to the previous behaviour rather
+than to a wrong answer:
 
-Outside herdr it falls back to the newest transcript for the current
-directory, walking up from `$PWD` to find it.
+1. **The sessions in this pane, ranked by who you spoke to last.** The
+   statusline records one marker per (pane, session) under
+   `~/.cache/claude-pane/`, and `ccl` ranks them by the last *human*
+   turn in each transcript.
+2. **herdr's own registration**, which is right whenever a pane holds a
+   single session.
+3. **The newest transcript** for the current directory, walking up from
+   `$PWD` — for plain shells and tmux.
+
+Tier 1 exists because herdr keeps only ONE session per pane and will
+not replace it when a second one starts, so a background job — which
+inherits the pane from wherever it was launched — is invisible to it.
+Without tier 1, `ccl` copied that pane's *first* session perfectly, and
+the wrong conversation arrived in your clipboard.
+
+Ranking is by last human turn rather than by file mtime because a
+session can write for hours with nobody speaking to it. Measured on a
+live pane: the foreground session's transcript was the more recently
+written, while its last human turn was eleven hours older than the
+background job's sitting beside it. mtime picked the stale one.
+
+**It tells you what it did.** Every copy reports the session, how it
+was chosen, and how long ago you last spoke there:
+
+```text
+copied 2805 chars from 319ca5df (pane, 1 in pane) · you last spoke 7m ago
+```
+
+Under the keybinding this arrives as a notification, because that is
+the only channel a detached command has. It also says `no human turn in
+this pane` when nothing there has ever been spoken to and the choice
+had to be made on weaker evidence, and names the project directory when
+the conversation comes from one you are not currently in.
 
 **When nothing happens.** Under a keybinding the script has no stdout,
 so failures surface as a herdr notification: no transcript for this

--- a/docs/claude-tooling.md
+++ b/docs/claude-tooling.md
@@ -55,6 +55,26 @@ live pane: the foreground session's transcript was the more recently
 written, while its last human turn was eleven hours older than the
 background job's sitting beside it. mtime picked the stale one.
 
+**One thing it cannot know, and says so.** `ccl` answers "which
+conversation belongs to this pane". Claude Code's agent view can render a
+conversation that belongs to *another* pane — a background job launched
+elsewhere — and then the inherited pane id, the process tree and herdr's
+registration all agree with each other and all three are wrong about what
+you are looking at.
+
+So after choosing, `ccl` checks the pane's rendered screen against what it
+picked. If they disagree it says so:
+
+```text
+copied 333 chars from 3bcaa0fe — WARNING: this pane is showing 8f485a02
+```
+
+This is a verifier, never a selector: it cannot change the answer, only
+describe it, so a screen it cannot read costs a missing warning rather than
+a wrong copy. Matching is restricted to **assistant text blocks**, because
+agents relay each other's replies inside tool arguments and a whole-file
+search names everyone in the relay instead of the author.
+
 **It tells you what it did.** Every copy reports the session, how it
 was chosen, and how long ago you last spoke there:
 

--- a/docs/upgrade-watch.md
+++ b/docs/upgrade-watch.md
@@ -128,7 +128,18 @@ maintenance.
 
    The fix does not depend on any of this — pane membership comes from
    `.local/lib/claude-pane-marker.sh` markers written by the statusline,
-   and ranking comes from each transcript's last human turn, neither of
-   which touches herdr. This is recorded because it is the reason the
-   mechanism exists, and because a future herdr that accepts `startup`
-   would make tier 2 correct again without making tier 1 wrong.
+   plus herdr's registration as a second, independent membership source,
+   and ranking comes from each transcript's last human turn. This is
+   recorded because it is the reason the mechanism exists, and because a
+   future herdr that accepts `startup` would make tier 2 correct again
+   without making tier 1 wrong.
+
+   **A fourth Claude Code format assumption**, alongside `.type`,
+   `.isSidechain` and `.message.content` above: ranking compares
+   `.timestamp` values as STRINGS, which is only correct while they share
+   one format. Both `…:41Z` and `…:41.090Z` occur, and at the same second
+   they sort backwards (`.` is below `Z` in ASCII), so the library
+   normalises every timestamp to carry a fractional part before
+   comparing. If Claude Code ever emits an offset other than `Z`, string
+   comparison stops being safe and the ranking needs a real date parse.
+   The suite's ranking fixture is the canary.

--- a/docs/upgrade-watch.md
+++ b/docs/upgrade-watch.md
@@ -104,3 +104,31 @@ maintenance.
    degrades to the old newest-file guess, which is wrong whenever two
    agents share a directory — silently pasting the other pane's
    reply. The suite asserts session-id selection beats mtime.
+
+   **Why that field alone is not enough (measured 2026-08-08, 0.8.0).**
+   herdr keeps at most ONE session per pane and will not replace it when
+   a report arrives with `session_start_source: "startup"` — which is
+   what every newly started session sends. In `state.rs`,
+   `session_report_allows_session_replacement` lists
+   `("herdr:claude", "claude", Some("clear" | "resume" | "compact"))`;
+   `startup` is present for codex, omp and hermes but deliberately
+   absent for claude. So the SECOND session in a pane — most often a
+   background job, which inherits `HERDR_PANE_ID` — can never claim it,
+   and `ccl` copied the first session's transcript perfectly: the wrong
+   conversation. It appeared to fix itself because `/compact` re-fires
+   `SessionStart` with an accepted source.
+
+   Three properties of that API make any change to it silent, so none of
+   them may be relied on as a signal:
+
+   - a REJECTED write still answers `{"type":"ok"}`;
+   - the pane `revision` counter moves neither on accept nor on reject;
+   - a report from any `source` other than the one holding the slot is
+     ignored, even with an accepted `session_start_source`.
+
+   The fix does not depend on any of this — pane membership comes from
+   `.local/lib/claude-pane-marker.sh` markers written by the statusline,
+   and ranking comes from each transcript's last human turn, neither of
+   which touches herdr. This is recorded because it is the reason the
+   mechanism exists, and because a future herdr that accepts `startup`
+   would make tier 2 correct again without making tier 1 wrong.

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -999,7 +999,7 @@ CCL_HERDR2
     run_test "claude-copy-last warns when the pane is showing a different conversation" \
         "rm -f '$CCL_TMP/notify-log' &&
          bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
-         grep -q 'WARNING: this pane is showing cccccccc' '$CCL_TMP/notify-log'"
+         grep -q 'WARNING: on-screen text belongs to cccccccc' '$CCL_TMP/notify-log'"
 
     # A relay must NOT trigger it: agents quote each other's replies
     # inside tool arguments, and a whole-file match would name every
@@ -1010,8 +1010,23 @@ CCL_HERDR2
     run_test "…and a relayed quotation of that text does not implicate the relayer" \
         "rm -f '$CCL_TMP/notify-log' &&
          bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
-         grep -q 'showing cccccccc' '$CCL_TMP/notify-log' &&
-         ! grep -q 'showing 11111111' '$CCL_TMP/notify-log'"
+         grep -q 'belongs to cccccccc' '$CCL_TMP/notify-log' &&
+         ! grep -q 'belongs to 11111111' '$CCL_TMP/notify-log'"
+
+    # AMBIGUITY MUST BE SILENCE, NOT THE FIRST GLOB HIT. If two sessions
+    # both emitted the on-screen text as their own assistant output, the
+    # screen identifies nothing — and reporting the alphabetically-first
+    # one as definite would be silent, arbitrary and stable, the exact
+    # pattern the rest of this mechanism exists to remove.
+    {
+        printf '{"type":"user","timestamp":"2031-01-01T00:00:00.000Z","message":{"content":"q"}}\n'
+        printf '{"type":"assistant","message":{"content":[{"type":"text","text":"this line belongs to the session on screen and nowhere else"}]}}\n'
+    } > "$CCL_TMP/projects/$CCL_SLUG/$CCL_MUTE_B.jsonl"
+    run_test "…and two sessions claiming the same on-screen text produce silence" \
+        "rm -f '$CCL_TMP/notify-log' &&
+         bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
+         ! grep -q 'WARNING' '$CCL_TMP/notify-log'"
+    rm -f "$CCL_TMP/projects/$CCL_SLUG/$CCL_MUTE_B.jsonl"
 
     # No screen, no conclusion. A pane running a shell, a cleared screen
     # or a scrolled viewport must produce silence, not a guess.

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -709,6 +709,8 @@ case "\$1 \$2" in
         else
             printf '{"result":{"process_info":{"tty":"%s"}}}' "$CCL_TMP/tty-capture"
         fi ;;
+    'pane read')
+        cat "$CCL_TMP/stub-screen" 2>/dev/null ;;
     'notification show')
         shift 2; printf '%s\n' "\$*" >> "$CCL_TMP/notify-log" ;;
 esac
@@ -960,6 +962,65 @@ CCL_HERDR2
              claude_pane_marker_sweep \"$CCL_TMP/projects\"' &&
          [ -e '$CCL_TMP/sweep/w1-p8--eeee0000-0000-0000-0000-00000000eeee' ]"
     rm -rf "$CCL_TMP/sweep"
+
+    # WHAT THE PANE DISPLAYS vs WHERE THE SESSION RUNS. Claude Code's
+    # agent view renders a session hosted by ANOTHER pane's process, so
+    # the inherited pane id, the process tree and herdr's registration all
+    # agree with each other and all three are wrong about what the user is
+    # looking at. Observed live: the Herddeck pane displayed a background
+    # job launched from a different pane, and ccl copied the pane's own
+    # (six-hour-stale) session, correctly by every rule it had.
+    #
+    # The rendered screen is the only signal derived from the user's
+    # attention. This is STRICTLY A VERIFIER — it cannot change the
+    # selection, so a bad needle costs a missing warning, never a wrong
+    # answer.
+    rm -f "$CCL_TMP/markers"/w1-p1--* "$CCL_TMP/stub-session"
+    : > "$CCL_TMP/markers/w1-p1--$CCL_STALE"
+    printf 'a distinctive sentence that only the stale session ever said\n' \
+        > "$CCL_TMP/stub-screen"
+    {
+        printf '{"type":"user","timestamp":"2020-01-01T00:00:00.000Z","message":{"content":"q"}}\n'
+        printf '{"type":"assistant","message":{"content":[{"type":"text","text":"a distinctive sentence that only the stale session ever said"}]}}\n'
+    } > "$CCL_TMP/projects/$CCL_SLUG/$CCL_STALE.jsonl"
+    run_test "claude-copy-last stays silent when the pane shows what it copied" \
+        "rm -f '$CCL_TMP/notify-log' &&
+         bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
+         ! grep -q 'WARNING' '$CCL_TMP/notify-log'"
+
+    # Now the screen shows text belonging to a session that is NOT a
+    # candidate for this pane at all — the live failure, reduced.
+    {
+        printf '{"type":"user","timestamp":"2031-01-01T00:00:00.000Z","message":{"content":"q"}}\n'
+        printf '{"type":"assistant","message":{"content":[{"type":"text","text":"this line belongs to the session on screen and nowhere else"}]}}\n'
+    } > "$CCL_TMP/projects/$CCL_SLUG/$CCL_FOREIGN.jsonl"
+    printf 'this line belongs to the session on screen and nowhere else\n' \
+        > "$CCL_TMP/stub-screen"
+    run_test "claude-copy-last warns when the pane is showing a different conversation" \
+        "rm -f '$CCL_TMP/notify-log' &&
+         bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
+         grep -q 'WARNING: this pane is showing cccccccc' '$CCL_TMP/notify-log'"
+
+    # A relay must NOT trigger it: agents quote each other's replies
+    # inside tool arguments, and a whole-file match would name every
+    # session in the relay rather than the one that wrote it. Only an
+    # ASSISTANT TEXT BLOCK counts.
+    printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"this line belongs to the session on screen and nowhere else"}}]}}\n' \
+        >> "$CCL_TMP/projects/$CCL_SLUG/$CCL_MUTE_A.jsonl"
+    run_test "…and a relayed quotation of that text does not implicate the relayer" \
+        "rm -f '$CCL_TMP/notify-log' &&
+         bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
+         grep -q 'showing cccccccc' '$CCL_TMP/notify-log' &&
+         ! grep -q 'showing 11111111' '$CCL_TMP/notify-log'"
+
+    # No screen, no conclusion. A pane running a shell, a cleared screen
+    # or a scrolled viewport must produce silence, not a guess.
+    : > "$CCL_TMP/stub-screen"
+    run_test "…and an empty screen produces no verdict at all" \
+        "rm -f '$CCL_TMP/notify-log' &&
+         bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
+         ! grep -q 'WARNING' '$CCL_TMP/notify-log'"
+    rm -f "$CCL_TMP/stub-screen" "$CCL_TMP/projects/$CCL_SLUG/$CCL_FOREIGN.jsonl"
 
     rm -f "$CCL_TMP/stub-session" "$CCL_TMP/markers"/w1-p1--*
     rm -f "$CCL_TMP/projects/$CCL_SLUG/$CCL_STALE.jsonl" \

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -668,7 +668,13 @@ CCL_HERDR
     chmod +x "$CCL_TMP/bin/pbcopy"
     # Fixed PATH: the ambient one may contain spaces (Application Support)
     # which cannot survive unquoted expansion inside the inner bash -c
-    CCL_ENV="PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/projects' HERDR_ACTIVE_PANE_ID=w1:p1 HERDR_BIN_PATH='$CCL_TMP/bin/herdr'"
+    # CLAUDE_PANE_MARKER_DIR is not optional hygiene: without it every ccl
+    # test below would read the DEVELOPER'S live markers out of
+    # ~/.cache/claude-pane and pass or fail depending on which panes
+    # happened to be open. Point it at an empty temp dir so each test
+    # states its own membership.
+    mkdir -p "$CCL_TMP/markers"
+    CCL_ENV="PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/projects' CLAUDE_PANE_MARKER_DIR='$CCL_TMP/markers' HERDR_ACTIVE_PANE_ID=w1:p1 HERDR_BIN_PATH='$CCL_TMP/bin/herdr'"
     CCL_B64=$(printf '%s' 'final answer' | base64 | tr -d '\n')
     run_test "claude-copy-last -c writes OSC 52 to the herdr pane tty" \
         "bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
@@ -696,7 +702,13 @@ case "\$1 \$2" in
         printf '{"result":{"pane":{"agent_session":{"value":"%s"}}}}' "\$sid" ;;
     'pane process-info')
         : > "$CCL_TMP/tty-capture"
-        printf '{"result":{"process_info":{"tty":"%s"}}}' "$CCL_TMP/tty-capture" ;;
+        shell_pid=\$(cat "$CCL_TMP/stub-shell-pid" 2>/dev/null)
+        if [ -n "\$shell_pid" ]; then
+            printf '{"result":{"process_info":{"tty":"%s","shell_pid":%s}}}' \\
+                "$CCL_TMP/tty-capture" "\$shell_pid"
+        else
+            printf '{"result":{"process_info":{"tty":"%s"}}}' "$CCL_TMP/tty-capture"
+        fi ;;
     'notification show')
         shift 2; printf '%s\n' "\$*" >> "$CCL_TMP/notify-log" ;;
 esac
@@ -708,7 +720,226 @@ CCL_HERDR2
     rm -f "$CCL_TMP/stub-session"
     # Without a pane (plain shell / tmux) it must still fall back to mtime
     run_test "claude-copy-last falls back to newest file without a pane id" \
-        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/projects' '$HOME/.local/bin/claude-copy-last'\")\" = 'OTHER PANE' ]"
+        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/projects' CLAUDE_PANE_MARKER_DIR='$CCL_TMP/markers' '$HOME/.local/bin/claude-copy-last'\")\" = 'OTHER PANE' ]"
+
+    # ------------------------------------------------------------------
+    # TWO SESSIONS IN ONE PANE. The bug this whole mechanism exists for:
+    # a background job inherits HERDR_PANE_ID from the pane it was
+    # launched in, so a pane holds two sessions — but herdr keeps only
+    # ONE registration and refuses to replace it when a new session
+    # reports session_start_source "startup" (verified against a running
+    # 0.8.0 server; resume/compact/clear are accepted, startup is not,
+    # and a rejected write still answers {"type":"ok"}). ccl therefore
+    # asked the pane, got the FIRST session, and copied it perfectly:
+    # the wrong conversation.
+    #
+    # Ranking is by LAST HUMAN TURN, not mtime. Measured on live panes,
+    # a foreground session's transcript was written three hours after
+    # its last human turn while a background job in the same pane had
+    # one 44 minutes old — mtime picked the stale one. So the fixture
+    # gives the STALE session the NEWER file, and mtime-ranking fails it.
+    CCL_STALE=aaaaaaaa-0000-0000-0000-00000000aaaa
+    CCL_LIVE=bbbbbbbb-0000-0000-0000-00000000bbbb
+    CCL_FOREIGN=cccccccc-0000-0000-0000-00000000cccc
+    {
+        printf '{"type":"user","timestamp":"2020-01-01T00:00:00.000Z","message":{"content":"old question"}}\n'
+        printf '{"type":"assistant","message":{"content":[{"type":"text","text":"STALE REPLY"}]}}\n'
+    } > "$CCL_TMP/projects/$CCL_SLUG/$CCL_LIVE.jsonl.tmp"
+    # LIVE has the OLDER file but the NEWER human turn
+    {
+        printf '{"type":"user","timestamp":"2030-01-01T00:00:00.000Z","message":{"content":"recent question"}}\n'
+        printf '{"type":"assistant","message":{"content":[{"type":"text","text":"LIVE REPLY"}]}}\n'
+    } > "$CCL_TMP/projects/$CCL_SLUG/$CCL_LIVE.jsonl"
+    rm -f "$CCL_TMP/projects/$CCL_SLUG/$CCL_LIVE.jsonl.tmp"
+    sleep 1
+    {
+        printf '{"type":"user","timestamp":"2020-01-01T00:00:00.000Z","message":{"content":"old question"}}\n'
+        printf '{"type":"assistant","message":{"content":[{"type":"text","text":"STALE REPLY"}]}}\n'
+    } > "$CCL_TMP/projects/$CCL_SLUG/$CCL_STALE.jsonl"
+    # herdr's registration points at the STALE session, as it does live
+    printf '%s' "$CCL_STALE" > "$CCL_TMP/stub-session"
+    : > "$CCL_TMP/markers/w1-p1--$CCL_STALE"
+    : > "$CCL_TMP/markers/w1-p1--$CCL_LIVE"
+    run_test "claude-copy-last: two sessions in one pane, newest human turn wins" \
+        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'LIVE REPLY' ]"
+
+    # Control 1 — the markers must be what did it. Remove them and the
+    # answer must revert to herdr's (stale) registration. Without this,
+    # the assertion above could pass for the wrong reason.
+    run_test "claude-copy-last: without markers it falls back to herdr's registration" \
+        "rm -f '$CCL_TMP/markers/w1-p1--$CCL_STALE' '$CCL_TMP/markers/w1-p1--$CCL_LIVE' &&
+         [ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'STALE REPLY' ]"
+
+    # Control 2 — LOAD-BEARING, not belt-and-braces. A membership error is
+    # the one failure mode that expresses itself as a WRONG answer rather
+    # than a fallback: a marker naming the wrong pane admits a foreign
+    # session to this pane's candidate set, and ranking will happily put it
+    # first if its human turn is newer. That is exactly the cross-pane
+    # bleed an earlier attempt at this shipped and had to be reverted.
+    {
+        printf '{"type":"user","timestamp":"2031-01-01T00:00:00.000Z","message":{"content":"newest of all"}}\n'
+        printf '{"type":"assistant","message":{"content":[{"type":"text","text":"FOREIGN PANE"}]}}\n'
+    } > "$CCL_TMP/projects/$CCL_SLUG/$CCL_FOREIGN.jsonl"
+    run_test "claude-copy-last: a marker for another pane is never selected" \
+        ": > '$CCL_TMP/markers/w1-p1--$CCL_STALE' &&
+         : > '$CCL_TMP/markers/w1-p1--$CCL_LIVE' &&
+         : > '$CCL_TMP/markers/w1-p9--$CCL_FOREIGN' &&
+         [ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'LIVE REPLY' ]"
+
+    # Control 3 — the janitor. A marker whose transcript is gone must be
+    # removed as it is passed over, or the cache grows without bound.
+    run_test "claude-copy-last reaps a marker whose transcript no longer exists" \
+        ": > '$CCL_TMP/markers/w1-p1--dddddddd-0000-0000-0000-00000000dddd' &&
+         bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\" >/dev/null &&
+         [ ! -e '$CCL_TMP/markers/w1-p1--dddddddd-0000-0000-0000-00000000dddd' ]"
+    rm -f "$CCL_TMP/markers/w1-p9--$CCL_FOREIGN"
+
+    # A marker's pane key comes from the writing session's own inherited
+    # HERDR_PANE_ID, so a session running elsewhere can name THIS pane.
+    # Filtering cannot catch that — the marker names the pane being read,
+    # so it is admitted correctly — and the candidate count corroborates
+    # it, since "2 in pane" is what a legitimate co-resident pair looks
+    # like. The process tree is the only independent witness. Here the
+    # pane's shell is a live process that is nobody's ancestor, so the
+    # marker's pid provably does not run in this pane.
+    sleep 30 &
+    CCL_SLEEPER=$!
+    printf '%s' "$CCL_SLEEPER" > "$CCL_TMP/stub-shell-pid"
+    printf 'pid=%s\n' "$$" > "$CCL_TMP/markers/w1-p1--$CCL_LIVE"
+    run_test "claude-copy-last rejects a marker whose process is not in the pane" \
+        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'STALE REPLY' ]"
+
+    # Fail-open is the other half and matters more: the check may only
+    # remove a claim that is PROVABLY false, never one that is merely
+    # unverified. An unrecorded pid must keep the candidate.
+    : > "$CCL_TMP/markers/w1-p1--$CCL_LIVE"
+    run_test "…but an unverifiable marker is kept, not rejected" \
+        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'LIVE REPLY' ]"
+    kill "$CCL_SLEEPER" 2>/dev/null || true
+    rm -f "$CCL_TMP/stub-shell-pid"
+
+    # Ancestry itself, asserted directly and in both directions, since the
+    # rejection above depends entirely on it being right.
+    sleep 30 &
+    CCL_CHILD=$!
+    run_test "pid ancestry: a child is recognised, an unrelated process is not" \
+        ". '$HOME/.local/lib/claude-pane-marker.sh' &&
+         claude_pane_pid_descends_from '$CCL_CHILD' '$$' &&
+         ! claude_pane_pid_descends_from '$$' '$CCL_CHILD'"
+    kill "$CCL_CHILD" 2>/dev/null || true
+
+    # CROSS-PROJECT MEMBERSHIP. A pane holds a session whose transcript
+    # lives under a DIFFERENT project directory whenever something was
+    # launched from it with another cwd — a background job, most often.
+    # That is genuinely this pane's conversation, so it must be reachable;
+    # it also widens the blast radius of a membership bug, which is why
+    # both directions are asserted rather than just the happy one.
+    CCL_ELSEWHERE=eeeeeeee-0000-0000-0000-00000000eeee
+    mkdir -p "$CCL_TMP/projects/-some-other-project"
+    {
+        printf '{"type":"user","timestamp":"2032-01-01T00:00:00.000Z","message":{"content":"newest anywhere"}}\n'
+        printf '{"type":"assistant","message":{"content":[{"type":"text","text":"ELSEWHERE REPLY"}]}}\n'
+    } > "$CCL_TMP/projects/-some-other-project/$CCL_ELSEWHERE.jsonl"
+    run_test "claude-copy-last finds this pane's session in another project dir" \
+        ": > '$CCL_TMP/markers/w1-p1--$CCL_ELSEWHERE' &&
+         [ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'ELSEWHERE REPLY' ]"
+    run_test "…and without its marker that session is unreachable" \
+        "rm -f '$CCL_TMP/markers/w1-p1--$CCL_ELSEWHERE' &&
+         [ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'LIVE REPLY' ]"
+
+    # NOBODY HAS EVER SPOKEN IN THIS PANE — every candidate lacks a human
+    # turn, so there is no evidence to rank on. Glob order must NOT decide:
+    # it is UUID-lexicographic, arbitrary AND stable, so it would pick the
+    # same wrong session every time with nothing indicating a guess was
+    # made. herdr's registration is real evidence and is consulted first.
+    rm -f "$CCL_TMP/markers/w1-p1--$CCL_STALE" "$CCL_TMP/markers/w1-p1--$CCL_LIVE"
+    # THREE candidates, not two: two cannot tell three rules apart, and a
+    # fixture that cannot distinguish the rule it tests is the "check that
+    # passes without looking" this repo keeps catching. Arranged so each
+    # rule names a DIFFERENT session —
+    #   glob order (lexicographic) -> MUTE_A   the rule being rejected
+    #   file mtime                 -> MUTE_B   the documented last resort
+    #   herdr's registration       -> MUTE_C   the rule being asserted
+    CCL_MUTE_A=11111111-0000-0000-0000-0000000000a1
+    CCL_MUTE_C=22222222-0000-0000-0000-0000000000c3
+    CCL_MUTE_B=33333333-0000-0000-0000-0000000000b2
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"MUTE A"}]}}\n' \
+        > "$CCL_TMP/projects/$CCL_SLUG/$CCL_MUTE_A.jsonl"
+    sleep 1
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"MUTE C"}]}}\n' \
+        > "$CCL_TMP/projects/$CCL_SLUG/$CCL_MUTE_C.jsonl"
+    sleep 1
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"MUTE B"}]}}\n' \
+        > "$CCL_TMP/projects/$CCL_SLUG/$CCL_MUTE_B.jsonl"
+    : > "$CCL_TMP/markers/w1-p1--$CCL_MUTE_A"
+    : > "$CCL_TMP/markers/w1-p1--$CCL_MUTE_B"
+    : > "$CCL_TMP/markers/w1-p1--$CCL_MUTE_C"
+    printf '%s' "$CCL_MUTE_C" > "$CCL_TMP/stub-session"
+    run_test "claude-copy-last: with no human turn anywhere, herdr's registration decides" \
+        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'MUTE C' ]"
+    # …and it must SAY it guessed. Under a keybinding the toast is the only
+    # channel, so that is where the provenance is asserted.
+    run_test "…and says 'no human turn in this pane' rather than guessing silently" \
+        "rm -f '$CCL_TMP/notify-log' &&
+         bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
+         grep -q 'no human turn in this pane' '$CCL_TMP/notify-log'"
+    # herdr names none of them: fall back to activity, not to filename
+    # entropy. MUTE_B is the newest file; MUTE_A is the one glob order
+    # would pick, so this cannot pass under the rule being rejected.
+    rm -f "$CCL_TMP/stub-session"
+    run_test "…and with herdr silent it falls back to activity, not glob order" \
+        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'MUTE B' ]"
+
+    rm -f "$CCL_TMP/stub-session" "$CCL_TMP/markers"/w1-p1--*
+    rm -f "$CCL_TMP/projects/$CCL_SLUG/$CCL_STALE.jsonl" \
+          "$CCL_TMP/projects/$CCL_SLUG/$CCL_LIVE.jsonl" \
+          "$CCL_TMP/projects/$CCL_SLUG/$CCL_FOREIGN.jsonl" \
+          "$CCL_TMP/projects/$CCL_SLUG/$CCL_MUTE_A.jsonl" \
+          "$CCL_TMP/projects/$CCL_SLUG/$CCL_MUTE_B.jsonl" \
+          "$CCL_TMP/projects/$CCL_SLUG/$CCL_MUTE_C.jsonl"
+    rm -rf "$CCL_TMP/projects/-some-other-project"
+
+    # The ranking predicate itself. Three entry kinds are type "user"
+    # without being a human speaking, and each was a real defect caught in
+    # review rather than a hypothetical:
+    #   tool_result      dominates the type — 728 of 802 array-content user
+    #                    entries in one measured transcript. Ranking on it
+    #                    tracks AGENT activity, i.e. mtime with extra steps.
+    #   isCompactSummary /compact writes a type:"user" entry whose content
+    #                    is a STRING and whose isMeta is null, so it passes
+    #                    both a shape filter and an isMeta filter. AUTO
+    #                    compaction fires unpredictably, so counting it
+    #                    hands the pane over at a random moment.
+    #   array-with-text  a real human turn can arrive as an array, so
+    #                    "string content only" misses genuine turns. Shape
+    #                    is the wrong discriminator in BOTH directions.
+    if [ -r "$HOME/.local/lib/claude-pane-marker.sh" ]; then
+        cat > "$CCL_TMP/rank.jsonl" <<'CCL_RANK'
+{"type":"user","timestamp":"2021-01-01T00:00:00.000Z","message":{"content":[{"type":"text","text":"a real turn, as an array"}]}}
+{"type":"user","timestamp":"2022-01-01T00:00:00.000Z","message":{"content":[{"type":"tool_result","content":"ls output"}]}}
+{"type":"user","timestamp":"2023-01-01T00:00:00.000Z","isCompactSummary":true,"isMeta":null,"message":{"content":"This session is being continued from a previous conversation"}}
+{"type":"user","timestamp":"2024-01-01T00:00:00.000Z","isSidechain":true,"message":{"content":"subagent turn"}}
+{"type":"user","timestamp":"2025-01-01T00:00:00.000Z","isMeta":true,"message":{"content":"system notice"}}
+CCL_RANK
+        run_test "last-human-turn ignores tool_result, compaction, sidechain and meta" \
+            "[ \"\$(. '$HOME/.local/lib/claude-pane-marker.sh' &&
+                   claude_pane_last_user_turn '$CCL_TMP/rank.jsonl')\" = '2021-01-01T00:00:00.000Z' ]"
+        # Deliberately-broken twin: if the predicate ever loosens to "any
+        # type==user", this fixture reports 2025 and the test above turns
+        # red. Assert the naive reading really does differ, so the test
+        # cannot pass by the fixture being toothless.
+        run_test "…and the naive reading of that fixture would differ" \
+            "[ \"\$(jq -rs '[.[]|select(.type==\"user\")|.timestamp]|last' '$CCL_TMP/rank.jsonl')\" = '2025-01-01T00:00:00.000Z' ]"
+        # Writer and reader must agree on the path. A divergence here does
+        # not error — it looks like "there are no markers", which is the
+        # silent shape of the failure this design replaced.
+        run_test "statusline writes a marker where claude-copy-last looks for it" \
+            "CLAUDE_PANE_MARKER_DIR='$CCL_TMP/agree' bash -c '
+                 . \"$HOME/.local/lib/claude-pane-marker.sh\"
+                 claude_pane_marker_write w1:p7 sess-123 &&
+                 [ \"\$(claude_pane_marker_sessions w1:p7)\" = sess-123 ]' &&
+             [ \"\$(stat -f '%Lp' '$CCL_TMP/agree')\" = 700 ]"
+    fi
 
     # Entry present + hook script gone = exit 127 every session. Warn,
     # never auto-repair: regenerating means running herdr's installer,
@@ -775,8 +1006,17 @@ CS_STUB
     cs_payload() {
         printf '{"session_id":"utcs","session_name":"%s","model":{"display_name":"O"},"workspace":{"current_dir":"%s"},"context_window":{"used_percentage":5},"cost":{"total_cost_usd":0,"total_duration_ms":0},"rate_limits":{}}' "$1" "$HOME"
     }
+    # HERDR_PANE_ID and CLAUDE_PANE_MARKER_DIR are pinned, not inherited.
+    # These tests run the REAL statusline, which writes its membership
+    # marker unconditionally — deliberately, since gating it behind
+    # SHOW_HERDR or the drift throttle was a suspect in an earlier failure.
+    # Unpinned, it inherited the developer's live pane and deposited a
+    # phantom candidate named after this fixture into a REAL pane's
+    # membership set. Making the ccl tests hermetic did not cover this: the
+    # containment was built for the reader, and the writer escaped it.
     cs_run() {
         cs_payload "$1" | env PATH="$CS_TMP/bin:$PATH" HERDR_TAB_ID=w1:t9 \
+            HERDR_PANE_ID=w1:p9 CLAUDE_PANE_MARKER_DIR="$CS_TMP/markers" \
             "$HOME/.local/bin/claude-statusline" >/dev/null 2>&1
         sleep 0.4
     }
@@ -861,6 +1101,19 @@ CS_STUB
     cs_run beta
     run_test "claude-statusline: drift check is throttled to once a minute" \
         "[ ! -s '$CS_TMP/calls.log' ]"
+    # A check on the TESTS rather than on the code, which is the only kind
+    # that catches this class. It is asserted AFTER every writer in the
+    # suite has run, and it names the fixture ids explicitly so a new
+    # fixture that escapes containment fails here instead of silently
+    # joining a real pane's candidate set.
+    #
+    # This is the same shape as the bug the whole mechanism exists for: a
+    # writer running in a context nobody accounted for, producing a
+    # plausible artifact, silently.
+    run_test "the suite leaves no fixture markers in the real marker directory" \
+        "! find \"\${XDG_CACHE_HOME:-\$HOME/.cache}/claude-pane\" -maxdepth 1 -type f 2>/dev/null |
+           grep -qE -- '--(utcs|sess-123|[abcd]{8}-0000-)'"
+
     rm -rf "$CS_TMP" /tmp/claude-statusline-name-utcs /tmp/claude-statusline-tabcheck-utcs /tmp/claude-tabname-w1-t9
 fi
 

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -890,6 +890,77 @@ CCL_HERDR2
     run_test "…and with herdr silent it falls back to activity, not glob order" \
         "[ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'MUTE B' ]"
 
+    # PARTIAL MEMBERSHIP. Markers can be INCOMPLETE — a session whose
+    # statusline is not ticking leaves none — and a pane with one marked
+    # and one unmarked session is indistinguishable from a healthy
+    # single-session pane: one candidate, ranked against nothing,
+    # selected, reported as "1 in pane", every guard passing. Observed
+    # live on w1:p1. herdr knows the unmarked session independently, so
+    # its registration JOINS the candidate set rather than waiting behind
+    # it as a fallback tier.
+    rm -f "$CCL_TMP/markers"/w1-p1--*
+    : > "$CCL_TMP/markers/w1-p1--$CCL_STALE"
+    printf '%s' "$CCL_LIVE" > "$CCL_TMP/stub-session"
+    run_test "claude-copy-last: herdr's session joins the candidate set, not just the fallback" \
+        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'LIVE REPLY' ]"
+
+    # AN UNREADABLE TRANSCRIPT IS NOT "NOBODY SPOKE HERE". Collapsing the
+    # two lets a candidate that might hold the most recent human turn lose
+    # silently to a readable one, and the tool then prints a confident age
+    # for the wrong session. It must be counted and said out loud.
+    printf 'not json at all\n' > "$CCL_TMP/projects/$CCL_SLUG/$CCL_FOREIGN.jsonl"
+    : > "$CCL_TMP/markers/w1-p1--$CCL_LIVE"
+    : > "$CCL_TMP/markers/w1-p1--$CCL_FOREIGN"
+    rm -f "$CCL_TMP/stub-session"
+    run_test "claude-copy-last reports an unreadable candidate instead of ranking it" \
+        "rm -f '$CCL_TMP/notify-log' &&
+         bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
+         grep -q '1 unreadable' '$CCL_TMP/notify-log'"
+    # …and the readable candidate is still the one selected: the broken
+    # one is skipped, not silently ranked as "never spoken to".
+    run_test "…and still selects the candidate it could read" \
+        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'LIVE REPLY' ]"
+    rm -f "$CCL_TMP/markers/w1-p1--$CCL_FOREIGN" \
+          "$CCL_TMP/projects/$CCL_SLUG/$CCL_FOREIGN.jsonl"
+
+    # A SESSION ID OUT OF A FILENAME IS UNVALIDATED INPUT, and it is used
+    # in two glob contexts downstream. A marker named `w1-p1--*` yields
+    # the id `*`, and `find -name "*.jsonl"` then matches the first
+    # transcript anywhere under the projects root. Only the same user can
+    # create that file — and the same user has already left a phantom
+    # marker in a live pane once this week.
+    : > "$CCL_TMP/markers/w1-p1--*"
+    run_test "a marker with a glob metacharacter is not accepted as a session id" \
+        "[ -z \"\$(CLAUDE_PANE_MARKER_DIR='$CCL_TMP/markers' bash -c '
+             . \"$HOME/.local/lib/claude-pane-marker.sh\"
+             claude_pane_marker_sessions w1:p1' | grep -Fx '*')\" ]"
+    rm -f "$CCL_TMP/markers/w1-p1--*"
+
+    # THE SWEEP. The per-copy janitor only ever visits its own pane's key,
+    # so a CLOSED pane's markers are never looked at again. Reaping needs
+    # both conditions: a dead session whose transcript survives is still
+    # the right answer for its pane until someone speaks there again.
+    mkdir -p "$CCL_TMP/sweep"
+    : > "$CCL_TMP/sweep/.swept"
+    printf 'pid=999999\n' > "$CCL_TMP/sweep/w1-p8--$CCL_STALE"
+    printf 'pid=999999\n' > "$CCL_TMP/sweep/w1-p8--ffffffff-0000-0000-0000-00000000ffff"
+    run_test "the sweep reaps a dead marker with no transcript, and keeps one with" \
+        "rm -f '$CCL_TMP/sweep/.swept' &&
+         CLAUDE_PANE_MARKER_DIR='$CCL_TMP/sweep' bash -c '
+             . \"$HOME/.local/lib/claude-pane-marker.sh\"
+             claude_pane_marker_sweep \"$CCL_TMP/projects\"' &&
+         [ -e '$CCL_TMP/sweep/w1-p8--$CCL_STALE' ] &&
+         [ ! -e '$CCL_TMP/sweep/w1-p8--ffffffff-0000-0000-0000-00000000ffff' ]"
+    # …and it must not run twice within the hour, or every live session's
+    # statusline would walk the directory every few seconds.
+    run_test "…and is throttled after it has run" \
+        "printf 'pid=999999\\n' > '$CCL_TMP/sweep/w1-p8--eeee0000-0000-0000-0000-00000000eeee' &&
+         CLAUDE_PANE_MARKER_DIR='$CCL_TMP/sweep' bash -c '
+             . \"$HOME/.local/lib/claude-pane-marker.sh\"
+             claude_pane_marker_sweep \"$CCL_TMP/projects\"' &&
+         [ -e '$CCL_TMP/sweep/w1-p8--eeee0000-0000-0000-0000-00000000eeee' ]"
+    rm -rf "$CCL_TMP/sweep"
+
     rm -f "$CCL_TMP/stub-session" "$CCL_TMP/markers"/w1-p1--*
     rm -f "$CCL_TMP/projects/$CCL_SLUG/$CCL_STALE.jsonl" \
           "$CCL_TMP/projects/$CCL_SLUG/$CCL_LIVE.jsonl" \


### PR DESCRIPTION
## The bug

`prefix+shift+O` copied a real Claude reply, perfectly — from the wrong
conversation. It looked intermittent, and "fixed itself" whenever the
session was compacted.

## Root cause

herdr keeps at most **one** Claude session per pane, and refuses to replace
it when a new session reports `session_start_source: "startup"` — which is
what every newly started session sends. From `state.rs`:

```rust
session_report_allows_session_replacement:
    ("herdr:claude", "claude", Some("clear" | "resume" | "compact"))
```

`startup` is listed for codex, omp and hermes and deliberately absent for
claude. So the **second** session in a pane — most often a background job,
which inherits `HERDR_PANE_ID` from wherever it was launched — can never
claim it. `ccl` asked the pane, got the first session, and copied it.

The apparent intermittency was `/compact`: it re-fires `SessionStart` with
an accepted source, silently repairing the registration.

This is not one machine's quirk. At the time of writing, **two panes** had
the identical shape — a foreground session plus a background job the human
was actually using — and neither was visible to herdr.

Three properties make any change to that API silent, so none of them is
relied on: a rejected write still answers `{"type":"ok"}`, the pane
`revision` counter moves neither on accept nor reject, and a report from any
`source` other than the one holding the slot is ignored.

## The fix

Three tiers, each falling through to the next, so a missing tier degrades to
the previous behaviour rather than to a wrong answer:

| tier | source | when it decides |
| --- | --- | --- |
| 1 | sessions in this pane, ranked by last human turn | normally |
| 2 | herdr's registration | a pane with one session |
| 3 | newest transcript by mtime | plain shells, tmux |

**Membership** comes from markers the statusline writes under
`~/.cache/claude-pane/`. The statusline runs for *every* live session —
useless for deciding which session you are talking to, and exactly the
enumeration herdr cannot provide.

**Ranking** comes from each transcript's last human turn. Nobody writes it,
so it cannot go stale, and it is not `mtime` for a measured reason: a session
writes for hours with nobody speaking to it. On a live pane the foreground
session's transcript was the *more recently written* while its last human
turn was **eleven hours older** than the background job's beside it. mtime
picked the stale one.

`tool_result`, `isMeta`, `isSidechain` and `isCompactSummary` entries are all
`type: "user"` without being a human speaking, and each was counted before
being excluded — 728 of 802 array-content user entries in one transcript are
tool results, and a naive reading drifted eleven minutes from the truth.
Auto-compaction matters most: it fires unpredictably and writes an entry that
passes both a shape filter and an `isMeta` filter.

## Trusting the markers

A marker's pane key comes from an inherited `HERDR_PANE_ID`, so a session can
name a pane it does not occupy — and **no filtering catches that**, because
the marker names the very pane being read, and the candidate count
corroborates it. The process tree is the independent witness. Markers record
the session pid, and a candidate is dropped only on a **contradiction**: pid
alive *and* provably outside this pane's process tree. Verified first that
both foreground sessions and background jobs descend from the pane's
`shell_pid`, so the check does not reject the sessions it exists to support.

## It now says what it did

```text
copied 2805 chars from 319ca5df (pane, 1 in pane) · you last spoke 7m ago
```

Plus `no human turn in this pane` when the choice had to be made on weaker
evidence, `N rejected` when a marker claimed a pane it does not occupy, and
the project directory when it differs from `$PWD`. Under the keybinding this
arrives as a toast — the only channel a detached command has — and it now
fires on **success**, not only on failure. Every bug in this tool's history
cost an hour because the copy succeeded and reported nothing.

## Tests: 141 → 158

Every new assertion was verified by deliberately breaking the mechanism it
covers and confirming the expected tests — and only those — went red.

- two sessions in one pane, newest human turn wins, with herdr's
  registration pointing at the stale one
- a marker for another pane is never selected
- a marker whose process is not in the pane is rejected — **and** an
  unverifiable one is kept, because fail-open is the half that matters
- cross-project membership, both directions
- with no human turn anywhere, herdr's registration decides, not glob order;
  three candidates, arranged so glob order, mtime and herdr each name a
  different one
- the ranking predicate, with a permanent twin asserting the naive reading of
  the same fixture differs

It also fixes a leak in the suite itself: the statusline tests ran the real
statusline, whose marker write is deliberately ungated, and deposited a
fixture-named marker into a **real** pane's membership set. Reader and writer
are both pinned to a temp directory now, with an assertion that no fixture
marker survives a run — the same shape as the bug this PR is about: a writer
running in a context nobody accounted for, producing a plausible artifact,
silently.
