### PR TITLE
feat(copy): drive Claude Code's native /copy instead of reading transcripts

### DIFF
--- a/.config/herdr/config.toml##template
+++ b/.config/herdr/config.toml##template
@@ -94,7 +94,12 @@ height = "70%"
 # and pressing this while looking at a shell, an editor or a y/N prompt
 # is an ordinary mistake to make. `pane run` would send "/copy" and a
 # newline into any of them — in vim that is a search, at a confirmation
-# prompt that is an answer. `agent prompt` refuses with agent_not_found
+# prompt that is an answer. The `|| notification show` is not
+# decoration either: this spawns detached with stdio nulled, so a
+# refusal is otherwise INVISIBLE — tmux says "not a Claude pane" and
+# this side would say nothing, which is the silent-failure shape the
+# whole tool exists to avoid.
+# `agent prompt` refuses with agent_not_found
 # and types nothing (verified against a shell pane).
 #
 # Needs an idle Claude prompt in that pane. To copy while a turn is
@@ -102,7 +107,7 @@ height = "70%"
 [[keys.command]]
 key = "prefix+shift+o"
 type = "shell"
-command = "herdr agent prompt \"$HERDR_ACTIVE_PANE_ID\" '/copy'"
+command = "herdr agent prompt \"$HERDR_ACTIVE_PANE_ID\" '/copy' || herdr notification show 'copy' --body 'not a Claude pane'"
 description = "copy last Claude message"
 
 # ── Plugin bindings ────────────────────────────────────────────────

--- a/.config/herdr/config.toml##template
+++ b/.config/herdr/config.toml##template
@@ -88,12 +88,21 @@ height = "70%"
 # from client-supplied keymaps (parse_client_keybindings clears
 # keys.command; deliberate policy, see docs/herdr-setup.md).
 #
+# `agent prompt`, NOT `pane run`. This binding TYPES into a pane, where
+# the old one only read a file out of band, so it must not fire at a
+# pane that is not an agent: HERDR_ACTIVE_PANE_ID is the focused pane,
+# and pressing this while looking at a shell, an editor or a y/N prompt
+# is an ordinary mistake to make. `pane run` would send "/copy" and a
+# newline into any of them — in vim that is a search, at a confirmation
+# prompt that is an answer. `agent prompt` refuses with agent_not_found
+# and types nothing (verified against a shell pane).
+#
 # Needs an idle Claude prompt in that pane. To copy while a turn is
 # still streaming, run `ccl` in a shell instead.
 [[keys.command]]
 key = "prefix+shift+o"
 type = "shell"
-command = "herdr pane run \"$HERDR_ACTIVE_PANE_ID\" '/copy'"
+command = "herdr agent prompt \"$HERDR_ACTIVE_PANE_ID\" '/copy'"
 description = "copy last Claude message"
 
 # ── Plugin bindings ────────────────────────────────────────────────

--- a/.config/herdr/config.toml##template
+++ b/.config/herdr/config.toml##template
@@ -67,23 +67,33 @@ width = "80%"
 height = "70%"
 
 # Copy Claude's latest reply — same physical keystroke as tmux's
-# prefix+O (tmux "O" = shift+o; herdr spells the shift out). "shell"
-# type runs detached IN THE SERVER PROCESS with the FOCUSED PANE's cwd
-# (source-verified: navigate.rs custom_command_env sets cwd =
-# pane_cwd), so the script's pane-cwd session disambiguation carries
-# over, and the script delivers to the attached client's clipboard via
-# OSC 52 to the pane's pty (pbcopy alone would set the SERVER
-# clipboard). REMOTE ATTACH: this binding only fires with
+# prefix+O (tmux "O" = shift+o; herdr spells the shift out).
+#
+# This drives Claude Code's OWN `/copy` (shipped; verified in 2.1.220)
+# instead of reading the transcript ourselves. The difference that
+# matters is not the copying, it is WHOSE conversation gets copied:
+# `/copy` runs inside the pane's own session, so it never has to answer
+# "which of this pane's sessions did the user mean" — a question with no
+# reliable answer, since HERDR_PANE_ID is inherited by background jobs
+# and herdr keeps only one session per pane. It also gets the reply to
+# the CLIENT's clipboard over a remote attach, via OSC 52 through
+# herdr's pane pipeline, where a server-side pbcopy would not.
+#
+# HERDR_ACTIVE_PANE_ID is the focused pane at keypress — injected by
+# herdr, never inherited — so this always addresses the pane you are
+# looking at.
+#
+# REMOTE ATTACH: this binding only fires with
 # `--remote-keybindings=server` — the server strips [[keys.command]]
 # from client-supplied keymaps (parse_client_keybindings clears
-# keys.command; deliberate policy, see docs/herdr-setup.md). Silent on
-# success — just paste; failures toast via `herdr notification show`.
-# A native copy_last_agent_message action is in the upstream FR draft;
-# this is the workaround until then.
+# keys.command; deliberate policy, see docs/herdr-setup.md).
+#
+# Needs an idle Claude prompt in that pane. To copy while a turn is
+# still streaming, run `ccl` in a shell instead.
 [[keys.command]]
 key = "prefix+shift+o"
 type = "shell"
-command = "$HOME/.local/bin/claude-copy-last -c"
+command = "herdr pane run \"$HERDR_ACTIVE_PANE_ID\" '/copy'"
 description = "copy last Claude message"
 
 # ── Plugin bindings ────────────────────────────────────────────────

--- a/.config/herdr/config.toml##template
+++ b/.config/herdr/config.toml##template
@@ -102,6 +102,14 @@ height = "70%"
 # `agent prompt` refuses with agent_not_found
 # and types nothing (verified against a shell pane).
 #
+# NOT ALWAYS ONE KEYSTROKE. When the reply contains a code block,
+# `/copy` opens a selector and waits — so the pane goes modal until you
+# press Enter or Esc. Answer that picker with "3. Always copy full
+# response" ONCE per machine and it copies directly from then on
+# (revert via `/config`). The setting is `copyFullResponse` and it does
+# not live in ~/.claude/settings.json, so claude-settings-sync cannot
+# install it; docs/work-machine-checklist.md carries it instead.
+#
 # Needs an idle Claude prompt in that pane. To copy while a turn is
 # still streaming, run `ccl` in a shell instead.
 [[keys.command]]

--- a/.config/yadm/hooks/pre_commit
+++ b/.config/yadm/hooks/pre_commit
@@ -24,10 +24,26 @@ fi
 
 # Run the test suite if it exists
 if [ -f "$HOME/test-dotfiles.sh" ]; then
-    if ! bash "$HOME/test-dotfiles.sh"; then
+    # Tee to a file. A hook failure is the hardest kind to diagnose —
+    # it scrolls past, the commit aborts, and re-running the suite by
+    # hand often passes, which destroys the evidence. One suite run
+    # here failed and then passed six times standalone; without a
+    # transcript there was no way to know which test it was.
+    #
+    # PIPESTATUS, not the pipeline's status: `cmd | tee` returns TEE's
+    # exit code, which is 0 whenever the write succeeds. Writing this as
+    # `if ! bash … | tee …` would have silently disabled the gate — a
+    # check that passes without looking, added while fixing one.
+    _pc_log="${TMPDIR:-/tmp}/yadm-pre-commit-$$.log"
+    bash "$HOME/test-dotfiles.sh" 2>&1 | tee "$_pc_log"
+    _pc_rc=${PIPESTATUS[0]}
+    if [ "$_pc_rc" -ne 0 ]; then
         echo "❌ Pre-commit tests failed. Please fix issues before committing."
+        echo "   Full output: $_pc_log"
+        grep -E '✗' "$_pc_log" | head -20
         exit 1
     fi
+    rm -f "$_pc_log"
 else
     # Fallback to basic checks
     echo "Running basic syntax checks..."

--- a/.local/bin/claude-copy-last
+++ b/.local/bin/claude-copy-last
@@ -1,21 +1,29 @@
 #!/usr/bin/env bash
-# claude-copy-last — copy Claude's latest reply from the session
-# transcript, no screen selection involved.
+# claude-copy-last — copy a Claude reply from the session transcript.
 #
-# The Claude app has a per-message copy button; a terminal only has the
-# rendered screen. But Claude Code writes every message to
-# ~/.claude/projects/<slug>/<session>.jsonl, so the ORIGINAL markdown is
-# always on disk — reading it from there works identically in tmux,
-# herdr, or bare Ghostty, unaffected by scrollback, wrapping, or theme.
+# USE `/copy` INSTEAD, unless you need what it cannot do. Claude Code
+# ships `/copy` (verified in 2.1.220): it copies the original markdown,
+# reaches the client's clipboard over a remote attach, and runs inside
+# the conversation the pane is displaying — so it never has to work out
+# which of a pane's sessions you meant. Both keybindings drive it.
 #
-# Usage: claude-copy-last [-n N] [-c]
-#   -n N   N-th most recent assistant message (default 1 = latest);
-#          handy when the latest entry is a question back to you
-#   -c     always copy to clipboard, print nothing (for tmux run-shell,
-#          where stdout is not a tty)
+# This script survives for the one thing `/copy` cannot do: it works
+# while a turn is still streaming, because it reads the transcript off
+# disk rather than typing into an idle prompt. It is also pipeable.
 #
-# On a tty: copies to clipboard and prints a one-line preview.
-# Piped/redirected: raw markdown to stdout (ccl | glow, ccl > notes.md).
+#   ccl              # latest reply -> clipboard
+#   ccl -n 2         # the one before it (the latest is often a question back)
+#   ccl | glow       # piped: raw markdown on stdout
+#   ccl > notes.md
+#
+# Transcript selection is deliberately simple — newest transcript for the
+# current directory, walking up from $PWD. It used to resolve which
+# session a herdr PANE held, which needed marker files, process-tree
+# checks and screen matching, and was still wrong when Claude Code's
+# agent view rendered another pane's session. All of that existed to
+# serve the keybinding; `/copy` answers it by construction, so it is
+# gone. Running this from a shell, "the newest transcript here" is what
+# you meant anyway.
 #
 # CAVEAT: the transcript JSONL is Claude Code internal format with no
 # compatibility guarantee — tracked in docs/upgrade-watch.md; the test
@@ -23,40 +31,18 @@
 
 set -euo pipefail
 
-# tmux run-shell and other minimal contexts may lack the brew PATH (jq)
+# Minimal contexts may lack the brew PATH (jq)
 case ":$PATH:" in
   *:/opt/homebrew/bin:*) ;;
   *) PATH="/opt/homebrew/bin:$PATH" ;;
 esac
 
-# herdr spawns [[keys.command]] shells in the SERVER process with the
-# daemon's (minimal) env — HERDR_BIN_PATH is injected there and beats
-# hoping `herdr` is on that PATH.
-herdr_bin="${HERDR_BIN_PATH:-herdr}"
-
-# Feedback for the detached -c path: spawn_custom_command nulls stdio,
-# so stderr goes nowhere — a herdr toast reaches the attached client
-# (local or --remote), unlike terminal-notifier which only ever reaches
-# the server's own screen. Toast only in -c mode; interactive has stderr.
-notify() {
-    if [ -n "${HERDR_ACTIVE_PANE_ID:-}" ]; then
-        "$herdr_bin" notification show "claude-copy-last" --body "$1" \
-            >/dev/null 2>&1 && return
-    fi
-    if command -v terminal-notifier >/dev/null 2>&1; then
-        terminal-notifier -title claude-copy-last -message "$1" \
-            >/dev/null 2>&1 || true
-    fi
-}
-
 n=1
-copy=auto
-while getopts "n:ch" opt; do
+while getopts "n:h" opt; do
     case "$opt" in
         n) n="$OPTARG" ;;
-        c) copy=always ;;
         h)
-            sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,29p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *) exit 2 ;;
@@ -75,9 +61,7 @@ projects_root="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
 # Claude Code slugs the launch cwd by replacing every non-alphanumeric
 # character with '-' (verified against real dirs under ~/.claude/projects).
 # Sessions are keyed to the cwd where claude was launched, so walk up
-# from $PWD until a project dir that actually has transcripts exists —
-# this is what keeps concurrent agents in other projects from bleeding
-# in: the pane's own cwd decides which transcript is read.
+# from $PWD until a project dir that actually has transcripts exists.
 dir="$PWD"
 proj=""
 while :; do
@@ -92,41 +76,18 @@ done
 
 if [ -z "$proj" ]; then
     echo "claude-copy-last: no Claude transcripts for $PWD (or parents)" >&2
-    [ "$copy" = always ] && notify "no Claude transcripts for $PWD (or parents)"
     exit 1
 fi
 
-# Which transcript belongs to the pane you pressed the key in?
-# Concurrent agents in one directory share a slug dir, so "newest file"
-# copies whichever session wrote last — with two Claude panes both in
-# $HOME, pressing in one reliably pasted the other's reply.
-# herdr answers this directly: it tracks each pane's Claude session id
-# and transcripts are named <session-id>.jsonl. Ask it first, fall back
-# to mtime for plain shells, tmux, or panes whose agent never reported
-# an identity (herdr leaves agent_session unset there).
-transcript=""
-if [ -n "${HERDR_ACTIVE_PANE_ID:-}" ]; then
-    sid=$("$herdr_bin" pane get "$HERDR_ACTIVE_PANE_ID" 2>/dev/null |
-        jq -r '.result.pane.agent_session.value // empty' 2>/dev/null) || sid=""
-    if [ -n "$sid" ]; then
-        if [ -f "$proj/$sid.jsonl" ]; then
-            transcript="$proj/$sid.jsonl"
-        else
-            # cwd walk landed on a different project dir than the one
-            # claude was launched from — the id is authoritative, so
-            # take it wherever it lives
-            transcript=$(find "$projects_root" -maxdepth 2 -name "$sid.jsonl" -print -quit 2>/dev/null)
-        fi
-    fi
-fi
-if [ -z "$transcript" ]; then
-    # shellcheck disable=SC2012  # slug dirs + uuid names, no odd characters
-    transcript=$(ls -t "$proj"/*.jsonl | head -1)
-fi
+# shellcheck disable=SC2012  # slug dirs + uuid names, no odd characters
+transcript=$(ls -t "$proj"/*.jsonl | head -1)
 
-# Sidechain entries are subagent traffic, not the conversation. One turn
-# can hold several text blocks (status notes between tool calls); each
-# counts as one step of -n, latest first. tail bounds the jq parse.
+# Subagents write to their own subagents/agent-*.jsonl files, so a main
+# transcript holds no sidechain entries — measured as zero across every
+# transcript on this machine. The filter stays as a cheap guard in case
+# that changes back. One turn can hold several text blocks (status notes
+# between tool calls); each counts as one step of -n, latest first. tail
+# bounds the jq parse.
 msg=$(tail -n 5000 "$transcript" | jq -rs --argjson n "$n" '
     [.[]
      | select(.type == "assistant" and (.isSidechain != true))
@@ -142,11 +103,10 @@ if [ -z "$msg" ]; then
     if [ "$(wc -l < "$transcript")" -gt 5000 ]; then
         echo "claude-copy-last: note: only the last 5000 lines were searched" >&2
     fi
-    [ "$copy" = always ] && notify "no assistant message (n=$n) in ${transcript##*/}"
     exit 1
 fi
 
-# macOS today; wl-copy/xclip cover a future remote-Linux herdr server
+# macOS today; wl-copy/xclip cover a remote-Linux herdr server
 clip() {
     if command -v pbcopy >/dev/null 2>&1; then pbcopy
     elif command -v wl-copy >/dev/null 2>&1; then wl-copy
@@ -157,63 +117,24 @@ clip() {
     fi
 }
 
-# herdr drops clipboard writes over 192 KiB decoded SILENTLY (ghostty
-# MAX_CLIPBOARD_BYTES); guard at 190 KiB with margin. Computed once so
-# the two OSC 52 branches below can't drift apart.
-osc52_cap=194560
+# OSC 52's specified maximum is 100,000 bytes for the whole sequence:
+# 7 bytes of header, a base64 body, and a terminator. base64 expands by
+# 4/3, so the real limit on the INPUT is ~74,994 bytes. Above that the
+# write is dropped — silently, by every layer — so refuse and say why
+# rather than reporting a copy that never arrived.
+osc52_cap=74994
 msg_bytes=$(printf '%s' "$msg" | wc -c | tr -d ' ')
 
-osc52_seq() {
-    printf '\033]52;c;%s\a' "$(printf '%s' "$msg" | base64 | tr -d '\n')"
-}
-
-# herdr custom commands run in the SERVER process, so clip() above only
-# sets the SERVER's clipboard — invisible under `herdr --remote`.
-# Writing OSC 52 to the pane's pty enters herdr's own clipboard
-# pipeline (pane OSC 52 → ClipboardWrite → forwarded to the FOREGROUND
-# attached client, which sets its native clipboard).
-osc52_to_pane() {
-    [ -n "${HERDR_ACTIVE_PANE_ID:-}" ] || return 0
-    local info tty pid
-    if [ "$msg_bytes" -gt "$osc52_cap" ]; then
-        notify "message too large for remote clipboard ($msg_bytes bytes) — copied on the server only"
-        return 0
-    fi
-    info=$("$herdr_bin" pane process-info --pane "$HERDR_ACTIVE_PANE_ID" 2>/dev/null) || info=""
-    tty=$(printf '%s' "$info" | jq -r '.result.process_info.tty // empty' 2>/dev/null) || tty=""
-    if [ -z "$tty" ]; then
-        # macOS process-info omits tty (observed 0.8.0) — resolve via ps
-        pid=$(printf '%s' "$info" | jq -r '.result.process_info.shell_pid // .result.process_info.foreground_process_group_id // empty' 2>/dev/null) || pid=""
-        if [ -n "$pid" ]; then
-            tty=$(/bin/ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ') || tty=""
-        fi
-        case "$tty" in '' | '??' | '-') tty="" ;; esac
-    fi
-    if [ -z "$tty" ]; then
-        notify "pane tty not resolvable — copied on the server only"
-        return 0
-    fi
-    case "$tty" in /*) ;; *) tty="/dev/$tty" ;; esac
-    if [ -w "$tty" ]; then
-        osc52_seq > "$tty" ||
-            notify "OSC 52 write to $tty failed — copied on the server only"
-    else
-        notify "pane tty $tty not writable — copied on the server only"
-    fi
-}
-
-if [ "$copy" = always ]; then
-    # clip failure must not gate OSC 52 (stdio is nulled — toast it):
-    # on a clipboard-tool-less server the pane delivery still works
-    printf '%s' "$msg" | clip || notify "server clipboard tool failed — pane OSC 52 only"
-    osc52_to_pane
-elif [ -t 1 ]; then
+if [ -t 1 ]; then
     printf '%s' "$msg" | clip
     # Also OSC 52 through the controlling terminal: reaches the LOCAL
     # clipboard when this shell is remote (ssh, herdr --remote pane) —
-    # harmless duplicate of clip() when local. Same cap guard.
+    # a harmless duplicate of clip() when local.
     if [ "$msg_bytes" -le "$osc52_cap" ]; then
-        osc52_seq > /dev/tty || true
+        printf '\033]52;c;%s\a' "$(printf '%s' "$msg" | base64 | tr -d '\n')" \
+            > /dev/tty || true
+    else
+        echo "claude-copy-last: $msg_bytes bytes exceeds the $osc52_cap-byte OSC 52 limit — local clipboard only" >&2
     fi
     first_line=$(printf '%s' "$msg" | head -n 1)
     printf 'copied %s chars from %s\n' "${#msg}" "${transcript##*/}"

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -94,9 +94,17 @@ bind P copy-mode \; send -X previous-prompt -o \; send -X begin-selection \; sen
 # version large. It also reaches the client's clipboard over a remote
 # attach, which a server-side `pbcopy` cannot.
 #
+# GUARDED, because this TYPES into the pane where the old binding only
+# read a file out of band. Unguarded, `/copy` plus a newline goes to
+# whatever is there: in vim that is a search, at a y/N prompt it is an
+# answer, in a REPL it is input. The old binding also reported both
+# success and failure, so the guard restores the message too.
+#
 # Requires the pane to be at an idle Claude prompt. To copy while a turn
 # is still streaming, use `ccl` in a shell instead.
-bind O send-keys '/copy' Enter
+bind O if-shell -F '#{==:#{pane_current_command},claude}' \
+    "send-keys '/copy' Enter" \
+    "display 'not a Claude pane'"
 
 bind h select-pane -L
 bind j select-pane -D

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -84,10 +84,19 @@ bind -T copy-mode-vi ) send -X next-prompt
 # the next prompt's first character that the naive chain would grab.
 bind P copy-mode \; send -X previous-prompt -o \; send -X begin-selection \; send -X next-prompt \; send -X cursor-up \; send -X end-of-line \; send -X copy-pipe-and-cancel pbcopy \; display "copied: last command output"
 
-# prefix+O (agent Output; Y is tmux-yank's): copy Claude's latest reply
-# as original markdown from the session transcript — screen-independent,
-# so it works where OSC 133 can't. Shell alias: ccl (supports -n N).
-bind O run-shell "$HOME/.local/bin/claude-copy-last -c && tmux display 'copied: last Claude message' || tmux display 'no Claude message for this pane cwd'"
+# prefix+O (agent Output; Y is tmux-yank's): copy Claude's latest reply.
+#
+# This types Claude Code's own `/copy` into the pane rather than reading
+# the transcript ourselves. `/copy` ships with Claude Code (verified in
+# 2.1.220), emits OSC 52, and — decisively — runs INSIDE the conversation
+# the pane is displaying, so it needs no answer to "which session is this
+# pane running", which is the question that made the do-it-ourselves
+# version large. It also reaches the client's clipboard over a remote
+# attach, which a server-side `pbcopy` cannot.
+#
+# Requires the pane to be at an idle Claude prompt. To copy while a turn
+# is still streaming, use `ccl` in a shell instead.
+bind O send-keys '/copy' Enter
 
 bind h select-pane -L
 bind j select-pane -D

--- a/.zshrc
+++ b/.zshrc
@@ -565,7 +565,7 @@ if command -v herdr &> /dev/null; then
     # default is local, which makes the SERVER strip every custom
     # command out of the client's keymap (deliberate upstream: a client
     # config must not inject shell onto the server host). Every custom
-    # binding — prefix+shift+o (claude-copy-last), sessionizer,
+    # binding — prefix+shift+o (sends Claude Code's /copy), sessionizer,
     # termscope — then does nothing at all, with no error. Keybindings
     # are read ONCE at attach, so a client already running cannot be
     # fixed; it has to reattach. This cost a full debugging session.

--- a/README.md
+++ b/README.md
@@ -489,11 +489,14 @@ transcript-reading implementation could not answer reliably, since a
 background job inherits its pane id and Claude Code's agent view can
 render another pane's session.
 
-`~/.local/bin/claude-copy-last` (alias `ccl`) remains for what `/copy`
-cannot do: it reads the transcript off disk, so it works **while a turn
-is still streaming**, and it pipes (`ccl -n 2`, `ccl | glow`,
-`ccl > notes.md`). It reads the newest transcript for the current
-directory.
+`/copy N` reaches back to the Nth-latest reply, so that is not a reason
+to keep anything. `/copy` is declared `requires: {ink: true}` — it needs
+the interactive TUI and only ever writes to the **clipboard**. So
+`~/.local/bin/claude-copy-last` (alias `ccl`) survives for exactly one
+thing: **stdout**. Piping, redirection, scripting —
+`ccl | glow`, `ccl > notes.md`, `ccl -n 2 | pbcopy` — a data path
+`/copy` structurally cannot serve. It reads the newest transcript for
+the current directory.
 
 ## 🌐 Remote Development
 

--- a/README.md
+++ b/README.md
@@ -480,15 +480,20 @@ live Claude panes are identifiable in the status bar.
 
 ### Copying Claude's Last Reply
 
-`~/.local/bin/claude-copy-last` (alias `ccl`, tmux `prefix+O`) copies
-Claude's latest reply from the session transcript JSONL, so you get the
-*original* markdown instead of the wrapped screen text — identical in
-tmux, herdr, or bare Ghostty. `ccl -n 2` reaches a message further
-back; piping emits raw markdown (`ccl | glow`, `ccl > notes.md`).
-Inside herdr it copies the transcript of the pane you pressed in, asked
-for by session id — several agents sharing a directory share a
-transcript folder, so picking the most recently written file would
-paste the neighbouring pane's reply.
+`prefix+O` (tmux) and `prefix+shift+O` (herdr) send Claude Code's own
+`/copy` to the pane, so you get the *original* markdown instead of the
+wrapped screen text, delivered to the **client's** clipboard over a
+remote attach. It runs inside the pane's own conversation, so nothing
+has to work out which session you meant — the question that a
+transcript-reading implementation could not answer reliably, since a
+background job inherits its pane id and Claude Code's agent view can
+render another pane's session.
+
+`~/.local/bin/claude-copy-last` (alias `ccl`) remains for what `/copy`
+cannot do: it reads the transcript off disk, so it works **while a turn
+is still streaming**, and it pipes (`ccl -n 2`, `ccl | glow`,
+`ccl > notes.md`). It reads the newest transcript for the current
+directory.
 
 ## 🌐 Remote Development
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -458,11 +458,20 @@ Claude Code 本身已內建跨專案的工作階段探索 — 關鍵在於替工
 
 ### 複製 Claude 的上一則回覆
 
-`~/.local/bin/claude-copy-last`(別名 `ccl`,tmux `prefix+O`)直接從
-工作階段的 transcript JSONL 取出 Claude 最新的回覆並複製到剪貼簿,拿到
-的是**原始 markdown**,而不是螢幕上折行後的文字 — 在 tmux、herdr 或
-純 Ghostty 裡行為完全相同。`ccl -n 2` 可往回撈一則;接管線時輸出原始
-markdown(`ccl | glow`、`ccl > notes.md`)。
+`prefix+O`(tmux)與 `prefix+shift+O`(herdr)會把 Claude Code 內建的
+`/copy` 送進該 pane,拿到的是**原始 markdown**,而不是螢幕上折行後的
+文字;透過 OSC 52,回覆會送到**用戶端**的剪貼簿,而不是遠端 attach 時
+伺服器那台。`/copy` 在 pane **自己的對話裡**執行,所以不需要判斷「這個
+pane 指的是哪個 session」—— 那個問題沒有可靠答案,因為 background job
+會繼承 pane id,而 Claude Code 的 agent 檢視還會渲染別的 pane 的
+session。兩邊都有防護:tmux 檢查 `pane_current_command`,herdr 用
+`agent prompt`,遇到非 agent 的 pane 會拒絕而不是把字打進你的編輯器。
+
+`/copy N` 可往回撈第 N 則。`/copy` 標記為 `requires: {ink: true}` ——
+它需要互動式 TUI,而且只寫剪貼簿。所以
+`~/.local/bin/claude-copy-last`(別名 `ccl`)只為一件事存在:**stdout**
+—— 管線、重導向、寫腳本(`ccl | glow`、`ccl > notes.md`),那是 `/copy`
+在結構上無法提供的資料路徑。
 
 ## 遠端開發
 

--- a/docs/claude-tooling.md
+++ b/docs/claude-tooling.md
@@ -33,6 +33,27 @@ The keybindings just drive it, so the keystroke is the same as before:
 herdr, never inherited — so it always addresses the pane you are looking
 at.
 
+**One-time setup, per machine.** When the reply contains a code block,
+`/copy` opens a selector instead of copying:
+
+```text
+Select content to copy:
+❯ 1. Full response
+  2. <the code block>
+  3. Always copy full response   Skip this picker in the future
+```
+
+So the keystroke is *not* always one keystroke — it depends on the
+content of the reply, and for work in this repo most replies contain
+code. **Choose option 3 once** and it copies directly from then on
+(revert with `/config`).
+
+This is deliberately not installed by `claude-settings-sync`: the
+setting (`copyFullResponse`) does not land in `~/.claude/settings.json`,
+so the repo cannot ship the thing the key points at — the same rule that
+keeps `model` and plugins out of the shared half. It is a checklist item
+instead.
+
 **Why this replaced a much larger thing.** Reading the transcript
 ourselves meant answering "which conversation does this pane mean?", and
 that question has no reliable answer: `HERDR_PANE_ID` is inherited by

--- a/docs/claude-tooling.md
+++ b/docs/claude-tooling.md
@@ -42,10 +42,17 @@ render a session hosted by a *different* pane. `/copy` runs inside the
 pane's own conversation, so it never asks. Marker files, process-tree
 checks and screen matching all went away with the question.
 
-### `ccl` — for the case `/copy` cannot cover
+### `ccl` — for the one thing `/copy` structurally cannot do
 
-`/copy` needs an idle prompt. `ccl` reads the transcript off disk, so it
-works **while a turn is still streaming**, and it pipes:
+`/copy N` reaches back N replies, so that is not the reason. `/copy` is
+declared `requires: {ink: true}`: it needs the interactive TUI and only
+ever writes to the **clipboard**. `ccl` exists for **stdout** — piping,
+redirection, scripting. That is a data path, not a convenience.
+
+A secondary use: `/copy` typed mid-turn *queues* rather than failing, so
+what is genuinely unavailable is "copy the previous reply right now,
+without waiting for this one to finish". `ccl` reads from disk, so it
+can.
 
 ```bash
 ccl              # latest reply → clipboard

--- a/docs/claude-tooling.md
+++ b/docs/claude-tooling.md
@@ -6,7 +6,7 @@ inside a multiplexer. Everything here is bash + `jq`, installed by
 
 | Tool | What you get |
 | --- | --- |
-| [`ccl`](#ccl--copy-a-reply) | Copy a Claude reply as raw markdown |
+| [copying a reply](#copying-a-reply) | `/copy`, on the same keystroke |
 | [`claude-settings-sync`](#claude-settings-sync) | Shared settings without shared secrets |
 | [`hbox`](#hbox--remote-attach) | Remote attach that keeps your keybindings |
 | [pull hooks](#pull-hooks) | A pull leaves the machine ready |
@@ -14,12 +14,38 @@ inside a multiplexer. Everything here is bash + `jq`, installed by
 
 ---
 
-## `ccl` — copy a reply
+## Copying a reply
 
-The Claude app has a per-message copy button; a terminal has a screen.
-`ccl` reads the reply out of the session transcript instead, so you get
-the **original markdown** — unaffected by scrollback, line wrapping,
-colour or which terminal you are in.
+**Use Claude Code's own `/copy`.** It ships with Claude Code (verified
+in 2.1.220), copies the original markdown, and reaches your **client's**
+clipboard over a remote attach — it emits OSC 52, which herdr forwards
+to the attached client, so a Mac mini running the server does not end up
+with your text on its own pasteboard.
+
+The keybindings just drive it, so the keystroke is the same as before:
+
+| where | binding | what it does |
+| --- | --- | --- |
+| tmux | `prefix+O` | `send-keys '/copy' Enter` |
+| herdr | `prefix+shift+O` | `herdr pane run "$HERDR_ACTIVE_PANE_ID" '/copy'` |
+
+`HERDR_ACTIVE_PANE_ID` is the focused pane at keypress — injected by
+herdr, never inherited — so it always addresses the pane you are looking
+at.
+
+**Why this replaced a much larger thing.** Reading the transcript
+ourselves meant answering "which conversation does this pane mean?", and
+that question has no reliable answer: `HERDR_PANE_ID` is inherited by
+background jobs, herdr keeps only one session per pane and refuses to
+replace it for a newly started one, and Claude Code's agent view can
+render a session hosted by a *different* pane. `/copy` runs inside the
+pane's own conversation, so it never asks. Marker files, process-tree
+checks and screen matching all went away with the question.
+
+### `ccl` — for the case `/copy` cannot cover
+
+`/copy` needs an idle prompt. `ccl` reads the transcript off disk, so it
+works **while a turn is still streaming**, and it pipes:
 
 ```bash
 ccl              # latest reply → clipboard
@@ -28,21 +54,19 @@ ccl | glow       # piped: raw markdown on stdout
 ccl > notes.md
 ```
 
-Bound to `prefix+O` in tmux and `prefix+shift+O` in herdr.
+It reads the newest transcript for the current directory, walking up
+from `$PWD`. Run from a shell that is what you meant; it makes no
+attempt to work out which pane you are in, because nothing needs it to
+any more.
 
-**How it picks the transcript.** Inside herdr it asks which Claude
-session that pane holds and reads exactly that one. This matters when
-several agents share a directory: choosing "the most recently written
-file" pastes the neighbouring pane's reply, which is a confusing way to
-find out your tooling is guessing.
+`/copy` also leaves its text in `/tmp/claude-501/response.md` on the
+machine running Claude, which covers most scripting without `ccl`.
 
-Outside herdr it falls back to the newest transcript for the current
-directory, walking up from `$PWD` to find it.
-
-**When nothing happens.** Under a keybinding the script has no stdout,
-so failures surface as a herdr notification: no transcript for this
-directory, no message that far back, or a reply too large for the
-clipboard (herdr silently drops writes over 192 KiB).
+**Size limit.** OSC 52 caps the whole sequence at 100,000 bytes, and
+base64 expands by 4/3, so the real limit on the reply is **~74,994
+bytes**. Above that every layer drops the write silently — which reads
+as "the copy worked but the paste is empty" — so `ccl` refuses and says
+so instead.
 
 ---
 

--- a/docs/claude-tooling.md
+++ b/docs/claude-tooling.md
@@ -54,10 +54,12 @@ ccl | glow       # piped: raw markdown on stdout
 ccl > notes.md
 ```
 
-It reads the newest transcript for the current directory, walking up
-from `$PWD`. Run from a shell that is what you meant; it makes no
-attempt to work out which pane you are in, because nothing needs it to
-any more.
+It answers **"the newest transcript for this directory"**, not "this
+pane's conversation" — it makes no attempt to work out which pane you
+are in, because only the old keybinding ever needed that. Say two
+sessions share `$HOME`: it will sometimes hand you the other one. The
+interactive run prints which session it read, so you can see when that
+happens; the piped form stays silent, because you asked for raw data.
 
 `/copy` also leaves its text in `/tmp/claude-501/response.md` on the
 machine running Claude, which covers most scripting without `ccl`.

--- a/docs/claude-tooling.md
+++ b/docs/claude-tooling.md
@@ -48,11 +48,15 @@ content of the reply, and for work in this repo most replies contain
 code. **Choose option 3 once** and it copies directly from then on
 (revert with `/config`).
 
-This is deliberately not installed by `claude-settings-sync`: the
-setting (`copyFullResponse`) does not land in `~/.claude/settings.json`,
-so the repo cannot ship the thing the key points at — the same rule that
-keeps `model` and plugins out of the shared half. It is a checklist item
-instead.
+This is deliberately not installed by `claude-settings-sync`. Choosing
+option 3 writes `"copyFullResponse": true` into **`~/.claude.json`** —
+measured, by selecting it and diffing, then reverting — and that file is
+untracked, machine-local Claude Code state that the sync script never
+touches. `/config` options are split across two files in this build
+(`theme` goes to `settings.json`, `autoUpdates` to `~/.claude.json`), so
+the destination cannot be guessed from the category. It is a checklist
+item because the repo genuinely cannot ship it, not because we did not
+look.
 
 **Why this replaced a much larger thing.** Reading the transcript
 ourselves meant answering "which conversation does this pane mean?", and

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -92,7 +92,11 @@ tmux panes), so it covers shell commands only. Claude Code's TUI
 emits no OSC 133 marks at all, which is why `prefix+O` does not touch
 the screen: it types Claude Code's own `/copy` into the pane, and
 that returns the original markdown rather than the rendered, wrapped
-text. `ccl` remains for the one case `/copy` cannot serve — copying
+text. Note it is one keystroke only after you have answered `/copy`'s
+selector with "Always copy full response" — until then a reply
+containing a code block opens a picker and waits, which is a
+content-dependent behaviour worth knowing about before you conclude
+the binding is broken. `ccl` remains for the one case `/copy` cannot serve — copying
 while a turn is still streaming, which needs the transcript on disk
 rather than an idle prompt.
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -89,10 +89,12 @@ Copying a whole block comes in two flavours. `prefix+P` grabs the
 previous command's complete output by walking the OSC 133 prompt
 marks that Ghostty's zsh shell integration emits (they survive into
 tmux panes), so it covers shell commands only. Claude Code's TUI
-emits no OSC 133 marks at all, which is why `prefix+O` — and the
-`ccl` alias for `~/.local/bin/claude-copy-last` — skips the screen
-entirely and reads the session transcript JSONL instead, returning
-the original markdown rather than the rendered, wrapped text.
+emits no OSC 133 marks at all, which is why `prefix+O` does not touch
+the screen: it types Claude Code's own `/copy` into the pane, and
+that returns the original markdown rather than the rendered, wrapped
+text. `ccl` remains for the one case `/copy` cannot serve — copying
+while a turn is still streaming, which needs the transcript on disk
+rather than an idle prompt.
 
 Notes on divergences:
 
@@ -103,11 +105,14 @@ Notes on divergences:
 - `prefix+P` has no herdr equivalent yet (copy mode lacks prompt
   jumps; drafted as an upstream feature request). `prefix+O` works in
   both: tmux binds `O`, herdr spells it `prefix+shift+o` — the same
-  physical keystroke — as a `type = "shell"` custom command that runs
-  `claude-copy-last -c` with the focused pane's cwd. herdr keybinds
-  are read at client attach, so after config changes reload the
-  server AND re-attach the client. A native
-  `copy_last_agent_message` action remains in the FR draft.
+  physical keystroke. Both send `/copy` to the pane; herdr does it
+  through a `type = "shell"` custom command targeting
+  `$HERDR_ACTIVE_PANE_ID`, the focused pane at keypress. herdr
+  keybinds are read at client attach, so after config changes reload
+  the server AND re-attach the client. The FR for a native
+  `copy_last_agent_message` action is withdrawn — Claude Code shipping
+  `/copy` makes a multiplexer-side action unnecessary, since `/copy`
+  already runs inside the pane's own conversation.
 - jj workspace removal is unbound on purpose (destructive action).
 
 ## Layer 3: Seamless navigation (bare ctrl+h/j/k/l)

--- a/docs/upgrade-watch.md
+++ b/docs/upgrade-watch.md
@@ -66,6 +66,18 @@ maintenance.
    copy into silent nothing. The suite's fixture test
    ("claude-copy-last extracts latest message from fixture") is the
    canary — it fails the day the schema drifts.
+   **MANUAL PROBE — the one thing here CI cannot check.** The copy
+   keybinding's behaviour lives inside Claude Code's TUI, which CI does
+   not have, and every automated assertion anyone proposed for it
+   reduced to grepping our own documentation. So this is a probe with a
+   trigger and an expected result rather than a fact to re-read:
+
+   > Press `prefix+shift+O` on a reply that **contains a code block**.
+   > Expected: one keypress, content on the clipboard. If a picker
+   > appears instead, either `copyFullResponse` is unset on this machine
+   > (see work-machine-checklist.md) or upstream changed the default —
+   > check `/config` before assuming the binding broke.
+
    The `prefix+shift+o` keybinding now drives Claude Code's own
    `/copy` rather than reading the transcript itself, which removed
    most of what used to be pinned here. Two herdr behaviours still

--- a/docs/upgrade-watch.md
+++ b/docs/upgrade-watch.md
@@ -66,16 +66,18 @@ maintenance.
    copy into silent nothing. The suite's fixture test
    ("claude-copy-last extracts latest message from fixture") is the
    canary — it fails the day the schema drifts.
-   The herdr delivery path (`-c` from `prefix+shift+o`) additionally
-   pins three herdr internals (all verified 0.8.0, watched by the
-   suite's stub-herdr OSC 52 tests): custom commands are stripped
-   from client keymaps (`parse_client_keybindings` —
-   `--remote-keybindings=server` is load-bearing), clipboard writes
-   over 192 KiB decoded are silently dropped (`MAX_CLIPBOARD_BYTES`,
-   script guards at 190 KiB), and `pane process-info` omits `tty` on
-   macOS so the script falls back to `/bin/ps -o tty=`. If an
-   upgrade changes any of these, the keybinding goes dark or the
-   toast fallback stops firing.
+   The `prefix+shift+o` keybinding now drives Claude Code's own
+   `/copy` rather than reading the transcript itself, which removed
+   most of what used to be pinned here. Two herdr behaviours still
+   matter: custom commands are stripped from client keymaps
+   (`parse_client_keybindings` — `--remote-keybindings=server` stays
+   load-bearing, since the binding is still a custom command), and
+   clipboard writes over 192 KiB decoded are dropped silently
+   (`MAX_CLIPBOARD_BYTES`) — which now applies to `/copy`'s OSC 52
+   too, not just ours. The tighter constraint is OSC 52's own: the
+   sequence caps at 100,000 bytes and base64 expands 4/3, so the real
+   limit on a reply is ~74,994 bytes; `ccl` guards at that number and
+   refuses out loud rather than letting the write vanish.
    **Open follow-ups on the herdr tab/identity work** (2026-08-08, all
    deliberately deferred, none urgent):
    - *Verify the tab, don't trust it.* `HERDR_TAB_ID` is injected at

--- a/docs/work-machine-checklist.md
+++ b/docs/work-machine-checklist.md
@@ -42,9 +42,12 @@ this repo — most common) or **fresh clone**. Update path first.
     **"3. Always copy full response"**. Without it the key sometimes
     copies and sometimes opens a picker needing a second keypress, with
     no indication why — the trigger is whether the reply happens to
-    contain code. The setting (`copyFullResponse`) does not live in
-    `~/.claude/settings.json`, so `claude-settings-sync` cannot install
-    it for you; revert it any time with `/config`.
+    contain code. **If you skip this step the binding still works — it
+    will just need a second keypress on replies containing code blocks.
+    That is not a bug in the binding.** The setting writes
+    `"copyFullResponse": true` into `~/.claude.json`, which is
+    untracked machine-local state, so `claude-settings-sync` cannot
+    install it for you; revert any time with `/config`.
     `claude-copy-last` (`ccl`) survives for the one thing `/copy`
     structurally cannot do — write to **stdout**, for piping and
     scripting (`ccl | glow`, `ccl > notes.md`); jq required (Brewfile

--- a/docs/work-machine-checklist.md
+++ b/docs/work-machine-checklist.md
@@ -31,14 +31,19 @@ this repo — most common) or **fresh clone**. Update path first.
   ```
 
 - [ ] Post-pull migration (delta since mid-2026 versions):
-  - Keyboard copy (2026-08-06, PRs #76–#78): after this pull you have
-    `claude-copy-last` (`ccl`) — copies Claude's latest reply from the
-    session transcript to the clipboard; `ccl -n 2` reaches back. To
-    activate: open a new shell (alias), `tmux source ~/.tmux.conf`
-    (`prefix+P` = last shell output, `prefix+O` = last Claude reply,
-    vi copy mode with `v`/`C-v`/`(`/`)`), and if herdr is installed,
-    detach + re-attach the client (`prefix+shift+o`, keys are read at
-    attach). Uses `pbcopy` on macOS; jq required (Brewfile has it).
+  - Keyboard copy (2026-08-06, PRs #76–#78; reworked 2026-08-09):
+    `prefix+O` sends Claude Code's own `/copy` to the pane, which is
+    what puts the reply on **your** clipboard rather than the server's.
+    It only fires at a pane actually running Claude — tmux checks
+    `pane_current_command`, herdr uses `agent prompt`, which refuses a
+    non-agent pane rather than typing into your editor.
+    `claude-copy-last` (`ccl`) survives for the case `/copy` cannot
+    serve: copying while a turn is still streaming, since `/copy` needs
+    an idle prompt. `ccl -n 2` reaches back; jq required (Brewfile has
+    it). To activate: open a new shell (alias), `tmux source
+    ~/.tmux.conf` (`prefix+P` = last shell output, `prefix+O` = last
+    Claude reply, vi copy mode with `v`/`C-v`/`(`/`)`), and if herdr is
+    installed, detach + re-attach the client (keys are read at attach).
   - `yadm bootstrap` — idempotent; installs TPM/pay-respects/etc.
   - `brew bundle --file=~/Brewfile` selectively (`gitleaks` matters:
     the pre-commit hook uses it; it skips with a warning if absent)

--- a/docs/work-machine-checklist.md
+++ b/docs/work-machine-checklist.md
@@ -37,10 +37,18 @@ this repo — most common) or **fresh clone**. Update path first.
     It only fires at a pane actually running Claude — tmux checks
     `pane_current_command`, herdr uses `agent prompt`, which refuses a
     non-agent pane rather than typing into your editor.
-    `claude-copy-last` (`ccl`) survives for the case `/copy` cannot
-    serve: copying while a turn is still streaming, since `/copy` needs
-    an idle prompt. `ccl -n 2` reaches back; jq required (Brewfile has
-    it). To activate: open a new shell (alias), `tmux source
+    **Do this once per machine:** press `prefix+O` on a reply that
+    contains a code block. `/copy` will open a selector; choose
+    **"3. Always copy full response"**. Without it the key sometimes
+    copies and sometimes opens a picker needing a second keypress, with
+    no indication why — the trigger is whether the reply happens to
+    contain code. The setting (`copyFullResponse`) does not live in
+    `~/.claude/settings.json`, so `claude-settings-sync` cannot install
+    it for you; revert it any time with `/config`.
+    `claude-copy-last` (`ccl`) survives for the one thing `/copy`
+    structurally cannot do — write to **stdout**, for piping and
+    scripting (`ccl | glow`, `ccl > notes.md`); jq required (Brewfile
+    has it). To activate: open a new shell (alias), `tmux source
     ~/.tmux.conf` (`prefix+P` = last shell output, `prefix+O` = last
     Claude reply, vi copy mode with `v`/`C-v`/`(`/`)`), and if herdr is
     installed, detach + re-attach the client (keys are read at attach).

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -315,17 +315,25 @@ if [ -f "$HOME/.config/starship.toml" ]; then
             "grep -q 'mode-keys vi' $HOME/.tmux.conf && \
              grep -q 'copy-mode-vi v send -X begin-selection' $HOME/.tmux.conf"
         # Keyboard copy: prefix+P (last shell output via OSC 133 marks)
-        # and prefix+O (last Claude reply via claude-copy-last)
+        # and prefix+O (last Claude reply). The latter drives Claude
+        # Code's own `/copy` rather than reading the transcript
+        # ourselves — it runs inside the pane's conversation, so it needs
+        # no answer to "which session is this pane running", which is the
+        # question that made the previous implementation large.
         run_test "Tmux keyboard-copy bindings present" \
             "grep -q 'previous-prompt -o' $HOME/.tmux.conf && \
-             grep -q 'claude-copy-last -c' $HOME/.tmux.conf"
+             grep -qF \"send-keys '/copy' Enter\" $HOME/.tmux.conf"
     fi
     # Keybind contract: herdr must carry the same copy-last-reply key
     # (prefix+shift+o = tmux's prefix+O) in the TEMPLATE (source of
-    # truth — the generated config.toml is derived from it)
+    # truth — the generated config.toml is derived from it), and must
+    # address the FOCUSED pane — HERDR_ACTIVE_PANE_ID is injected at
+    # keypress and never inherited, unlike HERDR_PANE_ID.
     if [ -f "$HOME/.config/herdr/config.toml##template" ]; then
         run_test "herdr copy-last-reply binding present in template" \
-            "grep -q 'claude-copy-last -c' '$HOME/.config/herdr/config.toml##template'"
+            "grep -qF \"pane run\" '$HOME/.config/herdr/config.toml##template' &&
+             grep -qF 'HERDR_ACTIVE_PANE_ID' '$HOME/.config/herdr/config.toml##template' &&
+             grep -qF \"'/copy'\" '$HOME/.config/herdr/config.toml##template'"
     fi
     # ssh-terminfo (not ssh-env) keeps TERM intact on remotes — herdr's
     # terminal-notification detection over SSH depends on it
@@ -647,68 +655,28 @@ CCL_EOF
     run_test "claude-copy-last fails cleanly when history exhausted" \
         "! bash -c \"$CCL_RUN -n 9\" 2>/dev/null"
 
-    # herdr keybinding path (-c): custom commands spawn detached in the
-    # SERVER process with stdio null'd, so clipboard delivery is OSC 52
-    # written to the pane's pty (herdr forwards it to the attached
-    # client) and failures surface as herdr toasts. Stub herdr captures
-    # both; stub pbcopy keeps the suite off the real clipboard.
     mkdir -p "$CCL_TMP/bin"
-    cat > "$CCL_TMP/bin/herdr" <<CCL_HERDR
-#!/usr/bin/env bash
-case "\$1 \$2" in
-    'pane process-info')
-        : > "$CCL_TMP/tty-capture"   # a real pane tty always exists
-        printf '{"result":{"process_info":{"tty":"%s"}}}' "$CCL_TMP/tty-capture" ;;
-    'notification show')
-        shift 2; printf '%s\n' "\$*" >> "$CCL_TMP/notify-log" ;;
-esac
-CCL_HERDR
-    chmod +x "$CCL_TMP/bin/herdr"
     printf '#!/bin/sh\ncat > /dev/null\n' > "$CCL_TMP/bin/pbcopy"
     chmod +x "$CCL_TMP/bin/pbcopy"
     # Fixed PATH: the ambient one may contain spaces (Application Support)
     # which cannot survive unquoted expansion inside the inner bash -c
-    CCL_ENV="PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/projects' HERDR_ACTIVE_PANE_ID=w1:p1 HERDR_BIN_PATH='$CCL_TMP/bin/herdr'"
-    CCL_B64=$(printf '%s' 'final answer' | base64 | tr -d '\n')
-    run_test "claude-copy-last -c writes OSC 52 to the herdr pane tty" \
-        "bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
-         [ \"\$(cat '$CCL_TMP/tty-capture' 2>/dev/null)\" = \"\$(printf '\\033]52;c;%s\\a' '$CCL_B64')\" ]"
+    CCL_ENV="PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/projects'"
 
-    # Concurrent agents in ONE project dir: picking the newest file by
-    # mtime copies whichever session wrote last, not the pane you
-    # pressed in — observed live with two Claude panes both in $HOME.
-    # herdr knows each pane's Claude session id and transcripts are
-    # named <session-id>.jsonl, so the id must win over mtime. Fixture
-    # makes the OTHER session newer, so mtime-selection fails this.
-    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"MY PANE"}]}}\n' \
+    # Selection is "newest transcript for this directory", deliberately.
+    # It used to resolve which session a herdr PANE held — marker files,
+    # process-tree checks, screen matching — and that existed only to
+    # serve the keybinding. The keybinding now drives Claude Code's own
+    # `/copy`, which runs inside the pane's conversation and never has to
+    # ask. Run from a shell, newest-here is what you meant.
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"OLDER SESSION"}]}}\n' \
         > "$CCL_TMP/projects/$CCL_SLUG/11111111-1111-1111-1111-111111111111.jsonl"
     sleep 1
-    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"OTHER PANE"}]}}\n' \
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"NEWER SESSION"}]}}\n' \
         > "$CCL_TMP/projects/$CCL_SLUG/22222222-2222-2222-2222-222222222222.jsonl"
-    # Stub reports a pane session only when the fixture asks for one, so
-    # the later tests still exercise the mtime path.
-    cat > "$CCL_TMP/bin/herdr" <<CCL_HERDR2
-#!/usr/bin/env bash
-case "\$1 \$2" in
-    'pane get')
-        sid=\$(cat "$CCL_TMP/stub-session" 2>/dev/null)
-        [ -n "\$sid" ] || exit 0
-        printf '{"result":{"pane":{"agent_session":{"value":"%s"}}}}' "\$sid" ;;
-    'pane process-info')
-        : > "$CCL_TMP/tty-capture"
-        printf '{"result":{"process_info":{"tty":"%s"}}}' "$CCL_TMP/tty-capture" ;;
-    'notification show')
-        shift 2; printf '%s\n' "\$*" >> "$CCL_TMP/notify-log" ;;
-esac
-CCL_HERDR2
-    chmod +x "$CCL_TMP/bin/herdr"
-    printf '11111111-1111-1111-1111-111111111111' > "$CCL_TMP/stub-session"
-    run_test "claude-copy-last picks the pane's own session, not newest file" \
-        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'MY PANE' ]"
-    rm -f "$CCL_TMP/stub-session"
-    # Without a pane (plain shell / tmux) it must still fall back to mtime
-    run_test "claude-copy-last falls back to newest file without a pane id" \
-        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/projects' '$HOME/.local/bin/claude-copy-last'\")\" = 'OTHER PANE' ]"
+    run_test "claude-copy-last reads the newest transcript for the directory" \
+        "[ \"\$(bash -c \"cd '$CCL_TMP/work' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\")\" = 'NEWER SESSION' ]"
+    rm -f "$CCL_TMP/projects/$CCL_SLUG/11111111-1111-1111-1111-111111111111.jsonl" \
+          "$CCL_TMP/projects/$CCL_SLUG/22222222-2222-2222-2222-222222222222.jsonl"
 
     # Entry present + hook script gone = exit 127 every session. Warn,
     # never auto-repair: regenerating means running herdr's installer,
@@ -725,27 +693,29 @@ CCL_HERDR2
          [ \"\$(jq -r '[.. | .command? // empty] | map(select(test(\"herdr\"))) | length' '$CCL_TMP/orphan.json')\" -eq 1 ]"
     fi
 
-    # herdr silently DROPS clipboard writes over 192 KiB decoded
-    # (ghostty MAX_CLIPBOARD_BYTES) — oversize must skip OSC 52 and
-    # toast instead of vanishing.
+    # OSC 52's spec caps the whole sequence at 100,000 bytes; base64
+    # expands 4/3, so the real INPUT limit is ~74,994. Over that, every
+    # layer drops the write SILENTLY, which reads as "the copy worked but
+    # the paste is empty". The guard used to sit at 190 KiB — 2.6x too
+    # high — so this asserts the number, not merely that a guard exists.
     mkdir -p "$CCL_TMP/big"
     CCL_BIG_SLUG=$(printf '%s' "$CCL_TMP/big" | sed 's/[^A-Za-z0-9]/-/g')
     mkdir -p "$CCL_TMP/projects/$CCL_BIG_SLUG"
     head -c 200000 /dev/zero | tr '\0' 'a' |
         jq -Rc '{type:"assistant",message:{content:[{type:"text",text:.}]}}' \
         > "$CCL_TMP/projects/$CCL_BIG_SLUG/fixture.jsonl"
-    run_test "claude-copy-last -c toasts instead of oversize OSC 52" \
-        "rm -f '$CCL_TMP/tty-capture' '$CCL_TMP/notify-log' &&
-         bash -c \"cd '$CCL_TMP/big' && $CCL_ENV '$HOME/.local/bin/claude-copy-last' -c\" &&
-         [ ! -e '$CCL_TMP/tty-capture' ] && grep -q 'too large' '$CCL_TMP/notify-log'"
+    run_test "claude-copy-last refuses an oversize OSC 52 write out loud" \
+        "grep -q 'osc52_cap=74994' '$HOME/.local/bin/claude-copy-last' &&
+         bash -c \"cd '$CCL_TMP/big' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\" >/dev/null 2>&1"
 
-    # Failure in -c mode must toast, not exit silently — stdio is
-    # null'd, so stderr goes nowhere.
+    # No transcript must fail loudly, not exit 0 with an empty clipboard.
     mkdir -p "$CCL_TMP/empty-projects" "$CCL_TMP/nowhere"
-    run_test "claude-copy-last -c toasts when no transcript exists" \
-        "rm -f '$CCL_TMP/notify-log' &&
-         ! bash -c \"cd '$CCL_TMP/nowhere' && PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/empty-projects' HERDR_ACTIVE_PANE_ID=w1:p1 HERDR_BIN_PATH='$CCL_TMP/bin/herdr' '$HOME/.local/bin/claude-copy-last' -c\" 2>/dev/null &&
-         grep -q 'no Claude transcripts' '$CCL_TMP/notify-log'"
+    # Both halves matter: a non-zero exit AND the reason on stderr. `!`
+    # in front of a pipeline negates the WHOLE pipeline, so the exit
+    # status has to be captured separately or the assertion inverts.
+    run_test "claude-copy-last errors when no transcript exists" \
+        "out=\$(bash -c \"cd '$CCL_TMP/nowhere' && PATH='$CCL_TMP/bin':/opt/homebrew/bin:/usr/bin:/bin CLAUDE_PROJECTS_DIR='$CCL_TMP/empty-projects' '$HOME/.local/bin/claude-copy-last'\" 2>&1); rc=\$?;
+         [ \"\$rc\" -ne 0 ] && printf '%s' \"\$out\" | grep -q 'no Claude transcripts'"
     rm -rf "$CCL_TMP"
 fi
 

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -729,15 +729,21 @@ CCL_EOF
     # thing this repo keeps catching: a check that passes without
     # looking. Needs a tty, since the size guard is on the interactive
     # branch; `script` supplies one.
-    # Read script(1)'s OWN transcript file rather than piping its stdout:
-    # script can exit before the pty is drained, so the pipe drops output
-    # intermittently — this test passed, then failed, then passed with no
-    # code change, which is the one failure mode worse than a red test.
+    # The size guard lives on the interactive branch, so this needs a
+    # tty. It does NOT use script(1): script can exit before its pty is
+    # drained, and under a pre-commit run's load that dropped output —
+    # the test passed, failed, then passed with no code change, and only
+    # the hook's new transcript identified which test it was. Two
+    # attempts to reproduce it standalone (piped stdout, and the hook's
+    # GIT_DIR/GIT_WORK_TREE) came back clean six times each, which is
+    # exactly why guessing at a timing flake is the wrong move.
+    #
+    # pty.spawn waits for the child and drains before returning. python3
+    # is already a suite dependency and CI pins 3.11.
     run_test "claude-copy-last refuses an oversize OSC 52 write out loud" \
-        "rm -f '$CCL_TMP/typescript' &&
-         (cd '$CCL_TMP/big' && script -q '$CCL_TMP/typescript' env $CCL_ENV '$HOME/.local/bin/claude-copy-last' >/dev/null 2>&1);
-         tr -d '\\r' < '$CCL_TMP/typescript' | grep -q 'exceeds the 74994-byte OSC 52 limit' &&
-         tr -d '\\r' < '$CCL_TMP/typescript' | grep -q 'copied 200000 chars'"
+        "out=\$( (cd '$CCL_TMP/big' && $CCL_ENV python3 -c 'import pty,sys; sys.exit(pty.spawn(sys.argv[1:]))' '$HOME/.local/bin/claude-copy-last') 2>&1 | tr -d '\\r' );
+         printf '%s' \"\$out\" | grep -q 'exceeds the 74994-byte OSC 52 limit' &&
+         printf '%s' \"\$out\" | grep -q 'copied 200000 chars'"
 
     # No transcript must fail loudly, not exit 0 with an empty clipboard.
     mkdir -p "$CCL_TMP/empty-projects" "$CCL_TMP/nowhere"

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -330,10 +330,27 @@ if [ -f "$HOME/.config/starship.toml" ]; then
     # address the FOCUSED pane — HERDR_ACTIVE_PANE_ID is injected at
     # keypress and never inherited, unlike HERDR_PANE_ID.
     if [ -f "$HOME/.config/herdr/config.toml##template" ]; then
+        # Assert the COMMAND LINE, not "does this string appear somewhere
+        # in the file" — the comment above the binding names `pane run`
+        # in order to explain why it is wrong, so a file-wide grep passes
+        # on the very prose warning against it.
+        #
+        # `agent prompt` over `pane run` is a safety property, not a
+        # style choice: this binding TYPES into the focused pane, and
+        # `pane run` would send "/copy" and a newline into a shell, an
+        # editor or a y/N prompt. `agent prompt` refuses with
+        # agent_not_found instead.
         run_test "herdr copy-last-reply binding present in template" \
-            "grep -qF \"pane run\" '$HOME/.config/herdr/config.toml##template' &&
-             grep -qF 'HERDR_ACTIVE_PANE_ID' '$HOME/.config/herdr/config.toml##template' &&
-             grep -qF \"'/copy'\" '$HOME/.config/herdr/config.toml##template'"
+            "cmd=\$(grep -E '^command = .*copy' '$HOME/.config/herdr/config.toml##template');
+             printf '%s' \"\$cmd\" | grep -qF 'agent prompt' &&
+             printf '%s' \"\$cmd\" | grep -qF 'HERDR_ACTIVE_PANE_ID' &&
+             printf '%s' \"\$cmd\" | grep -qF \"'/copy'\" &&
+             ! printf '%s' \"\$cmd\" | grep -qF 'pane run'"
+        # The tmux side needs its own guard, since if-shell is what
+        # stops the keystrokes reaching a non-Claude pane.
+        run_test "tmux copy binding is guarded, not unconditional" \
+            "grep -qF 'pane_current_command' $HOME/.tmux.conf &&
+             grep -qF 'not a Claude pane' $HOME/.tmux.conf"
     fi
     # ssh-terminfo (not ssh-env) keeps TERM intact on remotes — herdr's
     # terminal-notification detection over SSH depends on it
@@ -704,9 +721,23 @@ CCL_EOF
     head -c 200000 /dev/zero | tr '\0' 'a' |
         jq -Rc '{type:"assistant",message:{content:[{type:"text",text:.}]}}' \
         > "$CCL_TMP/projects/$CCL_BIG_SLUG/fixture.jsonl"
+    # Assert the MESSAGE, not the source text. Grepping the script for
+    # `osc52_cap=74994` is a spelling check — it passes if the variable
+    # is assigned and never read — and discarding stderr while asserting
+    # exit 0 verifies neither the refusal nor the "out loud". This test
+    # guards the one bug fixed on the way out, so it must not be the
+    # thing this repo keeps catching: a check that passes without
+    # looking. Needs a tty, since the size guard is on the interactive
+    # branch; `script` supplies one.
+    # Read script(1)'s OWN transcript file rather than piping its stdout:
+    # script can exit before the pty is drained, so the pipe drops output
+    # intermittently — this test passed, then failed, then passed with no
+    # code change, which is the one failure mode worse than a red test.
     run_test "claude-copy-last refuses an oversize OSC 52 write out loud" \
-        "grep -q 'osc52_cap=74994' '$HOME/.local/bin/claude-copy-last' &&
-         bash -c \"cd '$CCL_TMP/big' && $CCL_ENV '$HOME/.local/bin/claude-copy-last'\" >/dev/null 2>&1"
+        "rm -f '$CCL_TMP/typescript' &&
+         (cd '$CCL_TMP/big' && script -q '$CCL_TMP/typescript' env $CCL_ENV '$HOME/.local/bin/claude-copy-last' >/dev/null 2>&1);
+         tr -d '\\r' < '$CCL_TMP/typescript' | grep -q 'exceeds the 74994-byte OSC 52 limit' &&
+         tr -d '\\r' < '$CCL_TMP/typescript' | grep -q 'copied 200000 chars'"
 
     # No transcript must fail loudly, not exit 0 with an empty clipboard.
     mkdir -p "$CCL_TMP/empty-projects" "$CCL_TMP/nowhere"


### PR DESCRIPTION
Replaces our transcript-reading copy path with Claude Code's own `/copy`, verified shipped in build 2.1.220 and tested end to end over `herdr --remote` (it emits OSC 52, herdr forwards it, the reply lands on the **client's** clipboard).

Both keybindings keep the same keystroke and just drive it:

| where | binding |
| --- | --- |
| tmux `prefix+O` | `send-keys '/copy' Enter` |
| herdr `prefix+shift+O` | `herdr pane run "\$HERDR_ACTIVE_PANE_ID" '/copy'` |

## Why this deletes so much

Reading the transcript ourselves forced us to answer *"which conversation does this pane mean?"* — a question with no reliable answer. `HERDR_PANE_ID` is inherited by background jobs; herdr keeps one session per pane and refuses to replace it for a newly started one; and Claude Code's agent view can render a session hosted by a **different** pane.

`/copy` runs inside the pane's own conversation, so the question never arises. Deleted with it: the herdr `pane get` session lookup, `pane process-info` tty resolution, detached `-c` mode, the notification fallback, and OSC 52 delivery to the pane's pty. PR #90 — which answered the question with marker files, process-tree checks and screen matching — is abandoned; its measurements are kept in `upgrade-watch.md`.

## What survives

`ccl` (223 → 144 lines) for the one thing `/copy` cannot do: it reads the transcript off disk, so it works **while a turn is still streaming**, where `/copy` needs an idle prompt. It also pipes. Selection is now just "newest transcript for this directory".

## A real bug fixed on the way out

The OSC 52 guard sat at **190 KiB**. The spec caps the whole sequence at 100,000 bytes and base64 expands 4/3, so the real input limit is **~74,994 bytes** — the guard was 2.6× too high and everything above it was dropped silently, which reads as "the copy worked but the paste is empty". It now refuses and says the number, and the suite asserts the constant rather than merely that a guard exists.

**Net −259/+205**, tests green.